### PR TITLE
Support for searching from more than 1 map on a pg

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -138,7 +138,7 @@ L.Control.GeoSearch = L.Control.extend({
             $(this._map._container).focus();
         }
         else if (e.keyCode === enterKey) {
-            this.geosearch($('#leaflet-control-geosearch-qry').val());
+            this.geosearch($(e.currentTarget).children('#leaflet-control-geosearch-qry').val());
         }
     }
 });


### PR DESCRIPTION
I'm taking the input value of the target that was submitted instead of the first one in the DOM.

Tested FF 18, Chrome 24, Safari 6 all on OSX.

Closes #5
