### PR TITLE
Added a "showMarker" option.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,4 +40,14 @@ new L.Control.GeoSearch({
 }).addTo(map);
 ````
 
+There are other configurable options like setting the position of the search input and whether or not a marker should be displayed at the position of the search result.
+
+````
+new L.Control.GeoSearch({
+    provider: new L.GeoSearch.Provider.OpenStreetMap(),
+    position: 'topcenter',
+    showMarker: true
+}).addTo(map);
+````
+
 I really can't make it any harder. Checkout the providers to see how easy it is to write your own.

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -17,7 +17,8 @@ L.GeoSearch.Result = function (x, y, label) {
 
 L.Control.GeoSearch = L.Control.extend({
     options: {
-        position: 'topcenter'
+        position: 'topcenter',
+        showMarker: true
     },
 
     initialize: function (options) {
@@ -113,10 +114,12 @@ L.Control.GeoSearch = L.Control.extend({
     },
 
     _showLocation: function (location) {
-        if (typeof this._positionMarker === 'undefined')
-            this._positionMarker = L.marker([location.Y, location.X]).addTo(this._map);
-        else
-            this._positionMarker.setLatLng([location.Y, location.X]);
+        if (this.options.showMarker == true) {
+            if (typeof this._positionMarker === 'undefined')
+                this._positionMarker = L.marker([location.Y, location.X]).addTo(this._map);
+            else
+                this._positionMarker.setLatLng([location.Y, location.X]);
+        }
 
         this._map.setView([location.Y, location.X], this._config.zoomLevel, false);
         this._map.fireEvent('geosearch_showlocation', {Location: location});


### PR DESCRIPTION
Set this to true, and a marker will appear, set to false and the map
will only move to the search location but not show a marker.

This was necessary for a project I'm working on since the markers
on the map already represent something else.
