### PR TITLE
Reverse geocoding functionality

### DIFF
--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -38,6 +38,18 @@ L.Control.GeoSearch = L.Control.extend({
         };
     },
 
+    container: function() {
+        return this._container;
+    },
+
+    positionMarker: function() {
+        return this._positionMarker;
+    },
+
+    config: function() {
+        return this._config;
+    },
+
     onAdd: function (map) {
         var $controlContainer = $(map._controlContainer);
 

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -34,7 +34,8 @@ L.Control.GeoSearch = L.Control.extend({
             'searchLabel': options.searchLabel || 'search for address...',
             'notFoundMessage' : options.notFoundMessage || 'Sorry, that address could not be found.',
             'messageHideDelay': options.messageHideDelay || 3000,
-            'zoomLevel': options.zoomLevel || 18
+            'zoomLevel': options.zoomLevel || 18,
+            'showAddressTooltip': options.showAddressTooltip || true,
         };
     },
 
@@ -129,6 +130,12 @@ L.Control.GeoSearch = L.Control.extend({
             this._positionMarker = L.marker([location.Y, location.X]).addTo(this._map);
         else
             this._positionMarker.setLatLng([location.Y, location.X]);
+
+        if( this._config.showAddressTooltip ) {
+            this._map.removeLayer(this._positionMarker);
+            this._positionMarker.options.title = location.Label;
+            this._map.addLayer(this._positionMarker);
+        }
 
         this._map.setView([location.Y, location.X], this._config.zoomLevel, false);
         this._map.fireEvent('geosearch_showlocation', {Location: location});

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -37,6 +37,7 @@ L.Control.GeoSearch = L.Control.extend({
             'zoomLevel': options.zoomLevel || 18,
             'showAddressTooltip': typeof(options.showAddressTooltip) == "undefined" ? true:options.showAddressTooltip,
             'reverseLookup': typeof(options.reverseLookup) == "undefined" ? false:options.reverseLookup,
+            'markerOptions': options.markerOptions || {},
         };
     },
 
@@ -87,9 +88,12 @@ L.Control.GeoSearch = L.Control.extend({
 
         L.DomEvent.disableClickPropagation(this._container);
 
-        this._positionMarker = L.marker(this._map.getCenter(),{
+        var markerOptions = L.Util.extend({},this.config().markerOptions);
+        markerOptions = L.Util.extend(markerOptions,{
             draggable:this._config.reverseLookup && (typeof this._config.provider.GetAddresses == 'function'),
-        }).addTo(this._map);
+        });
+
+        this._positionMarker = L.marker(this._map.getCenter(),markerOptions).addTo(this._map);
         this._map.removeLayer(this._positionMarker);
         this._positionMarker.on('dragend',this._onMarkerDrop.bind(this));
 

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -151,6 +151,8 @@ L.Control.GeoSearch = L.Control.extend({
         if( results.length ) {
             this._map.fireEvent('geosearch_foundaddresses', {Addresses: results});
             this._showLocation(results[0],lat,lng);
+        } else {
+            this._printError(this._config.notFoundMessage);
         }
     },
 

--- a/src/js/l.control.geosearch.js
+++ b/src/js/l.control.geosearch.js
@@ -35,7 +35,7 @@ L.Control.GeoSearch = L.Control.extend({
             'notFoundMessage' : options.notFoundMessage || 'Sorry, that address could not be found.',
             'messageHideDelay': options.messageHideDelay || 3000,
             'zoomLevel': options.zoomLevel || 18,
-            'showAddressTooltip': options.showAddressTooltip || true,
+            'showAddressTooltip': typeof(options.showAddressTooltip) == "undefined" ? true:options.showAddressTooltip,
         };
     },
 

--- a/src/js/l.geosearch.provider.esri.js
+++ b/src/js/l.geosearch.provider.esri.js
@@ -36,5 +36,38 @@ L.GeoSearch.Provider.Esri = L.Class.extend({
             ));
         
         return results;
-    }
+    },
+
+    GetAddresses: function(latlng, callback) {
+        var lat = latlng[0];
+        var lon = latlng[1];
+
+        var parameters = L.Util.extend({
+            location: lon+','+lat,
+            distance: 100,
+            f: 'pjson'
+        }, this.options);
+
+        var url = 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/reverseGeocode' + L.Util.getParamString(parameters);
+        $.getJSON(url, function (data) {
+            var results = [];
+            if(data.address && data.location) {
+                var address = "";
+                for(var i in data.address) {
+                    if( !data.address[i] )
+                        continue;
+                    if( address.length )
+                        address += ', ';
+                    address += data.address[i];
+                }
+                results.push(new L.GeoSearch.Result(
+                    data.location.x, 
+                    data.location.y, 
+                    address
+                ));
+            }
+            if(typeof callback == 'function')
+                callback(results);
+        }.bind(this));
+    },
 });

--- a/src/js/l.geosearch.provider.google.js
+++ b/src/js/l.geosearch.provider.google.js
@@ -47,4 +47,32 @@ L.GeoSearch.Provider.Google = L.Class.extend({
                 callback(results);
         });
     },
+
+    GetAddresses: function(latlng, callback) {
+        var lat = latlng[0];
+        var lon = latlng[1];
+        var geocoder = L.GeoSearch.Provider.Google.Geocoder;
+        
+        var parameters = L.Util.extend({
+            latLng: new google.maps.LatLng(lat,lon),
+        }, this.options);
+
+        var results = geocoder.geocode(parameters, function(data,status){
+            data = {results: data};
+
+            if (data.results.length == 0)
+                return [];
+
+            var results = [];
+            for (var i = 0; i < data.results.length; i++)
+                results.push(new L.GeoSearch.Result(
+                    data.results[i].geometry.location.lng(), 
+                    data.results[i].geometry.location.lat(), 
+                    data.results[i].formatted_address
+                ));
+
+            if(typeof callback == 'function')
+                callback(results);
+        });
+    },
 });

--- a/src/js/l.geosearch.provider.openstreetmap.js
+++ b/src/js/l.geosearch.provider.openstreetmap.js
@@ -36,5 +36,28 @@ L.GeoSearch.Provider.OpenStreetMap = L.Class.extend({
             ));
         
         return results;
-    }
+    },
+
+    GetAddresses: function(latlng, callback) {
+        var lat = latlng[0];
+        var lon = latlng[1];
+
+        var parameters = L.Util.extend({
+            lat: lat,
+            lon: lon,
+            format: 'json'
+        }, this.options);
+
+        var url = 'http://nominatim.openstreetmap.org/reverse' + L.Util.getParamString(parameters);
+        $.getJSON(url, function (data) {
+            var results = [];
+            results.push(new L.GeoSearch.Result(
+                data.lon, 
+                data.lat, 
+                data.display_name
+            ));
+            if(typeof callback == 'function')
+                callback(results);
+        }.bind(this));
+    },
 });


### PR DESCRIPTION
It is sometimes useful to have reverse geocoding lookup as well as address search.

These changes make reverse geocoding lookup feature available while dragging the marker. Dragging is switched on only for providers supporting reverse geocoding lookup feature.

The 'reverseLookup' option switches on the reverse geocoding lookup feature, while 'showAddressTooltip' makes direct and reverse geocoding result visible as a tooltip for the marker.

The new 'geosearch_foundaddresses' event is available for the map additionally as a result of reverse geocoding lookup.

The geosearch_showlocation event happens for the reverse lookup as well.

Reverse geocoding support is optional for provider. Three major providers have reverse lookup option now. Others are address-search only.


<!---
@huboard:{"order":25.0,"milestone_order":25,"custom_state":""}
-->
