### PR TITLE
Update l.geosearch.provider.esri.js

### DIFF
--- a/src/js/l.geosearch.provider.esri.js
+++ b/src/js/l.geosearch.provider.esri.js
@@ -19,7 +19,8 @@ L.GeoSearch.Provider.Esri = L.Class.extend({
             f: 'pjson'
         }, this.options);
 
-        return 'http://geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find'
+        return location.protocol 
+            + '//geocode.arcgis.com/arcgis/rest/services/World/GeocodeServer/find'
             + L.Util.getParamString(parameters);
     },
 


### PR DESCRIPTION
Added detection of protocol used in browser connection: http or https. Use: "location.protocol", according to: http://stackoverflow.com/questions/2855529/js-detect-https.
Of that depends protocol used to connect to ESRI service.
