### PR TITLE
Relaxes nodent-runtime dependency requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "testdouble": "^1.10.1",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2",
-    "nodent-runtime": "latest"
+    "nodent-runtime": "3.x.x"
   },
   "dependencies": {
     "lodash.debounce": "^4.0.8"

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "testdouble": "^1.10.1",
     "webpack": "^1.14.0",
     "webpack-dev-server": "^1.16.2",
-    "nodent-runtime": "^3.0.4"
+    "nodent-runtime": "latest"
   },
   "dependencies": {
     "lodash.debounce": "^4.0.8"


### PR DESCRIPTION
* Now uses latest instead of a specific version

This is an attempt to avoid issues for people using older versions of npm. 

Related to #111 


Another alternative woudl be to ask for nodent-runtime version to be >= 2.0.0