### PR TITLE
Fix failing search for OSM and LocationIQ, fix #144

### DIFF
--- a/src/leafletControl.js
+++ b/src/leafletControl.js
@@ -83,7 +83,7 @@ const Control = {
       this.resultList = new ResultList({
         handleClick: ({ result }) => {
           input.value = result.label;
-          this.onSubmit({ query: result.label });
+          this.onSubmit({ query: result.label, data: result });
         },
       });
 
@@ -186,12 +186,14 @@ const Control = {
 
     const { input } = this.searchElement.elements;
 
+    const list = this.resultList;
+
     if (event.keyCode === ENTER_KEY) {
-      this.onSubmit({ query: input.value });
+      const item = list.select(list.selected);
+      this.onSubmit({ query: input.value, data: item });
       return;
     }
-
-    const list = this.resultList;
+    
     const max = list.count() - 1;
     if (max < 0) {
       return;

--- a/src/leafletControl.js
+++ b/src/leafletControl.js
@@ -193,7 +193,7 @@ const Control = {
       this.onSubmit({ query: input.value, data: item });
       return;
     }
-    
+
     const max = list.count() - 1;
     if (max < 0) {
       return;

--- a/src/providers/locationIQProvider.js
+++ b/src/providers/locationIQProvider.js
@@ -51,7 +51,7 @@ export default class Provider extends BaseProvider {
 
     const request = await fetch(url);
     const json = await request.json();
-    return this.parse({ data: json });
+    return this.parse({ data: data ? [json] : json });
   }
 
   translateOsmType(type) {

--- a/src/providers/locationIQProvider.js
+++ b/src/providers/locationIQProvider.js
@@ -13,6 +13,19 @@ export default class Provider extends BaseProvider {
     return `${protocol}//locationiq.org/v1/search.php?${paramString}`;
   }
 
+  endpointReverse({ data, protocol } = {}) {
+    const { params } = this.options;
+
+    const paramString = this.getParamString({
+      ...params,
+      format: 'json',
+      osm_id: data.raw.osm_id,
+      osm_type: this.translateOsmType(data.raw.osm_type),
+    });
+
+    return `${protocol}//locationiq.org/v1/reverse.php?${paramString}`;
+  }
+
   parse({ data }) {
     return data.map(r => ({
       x: r.lon,
@@ -24,5 +37,32 @@ export default class Provider extends BaseProvider {
       ],
       raw: r,
     }));
+  }
+
+  async search({ query, data }) {
+    // eslint-disable-next-line no-bitwise
+    const protocol = ~location.protocol.indexOf('http') ? location.protocol : 'https:';
+    if (data) {
+      const url = this.endpointReverse({ data, protocol });
+    } else {
+      const url = this.endpoint({ query, protocol });
+    }
+
+    const request = await fetch(url);
+    const json = await request.json();
+    return this.parse({ data: json });
+  }
+
+  translateOsmType(osm_type) {
+    if (osm_type === "node") {
+      return "N";
+    }
+    if (osm_type === "way") {
+      return "W";
+    }
+    if (osm_type === "relation") {
+      return "R";
+    }
+    return ""; // Unknown
   }
 }

--- a/src/providers/locationIQProvider.js
+++ b/src/providers/locationIQProvider.js
@@ -19,7 +19,9 @@ export default class Provider extends BaseProvider {
     const paramString = this.getParamString({
       ...params,
       format: 'json',
+      // eslint-disable-next-line camelcase
       osm_id: data.raw.osm_id,
+      // eslint-disable-next-line camelcase
       osm_type: this.translateOsmType(data.raw.osm_type),
     });
 
@@ -42,27 +44,26 @@ export default class Provider extends BaseProvider {
   async search({ query, data }) {
     // eslint-disable-next-line no-bitwise
     const protocol = ~location.protocol.indexOf('http') ? location.protocol : 'https:';
-    if (data) {
-      const url = this.endpointReverse({ data, protocol });
-    } else {
-      const url = this.endpoint({ query, protocol });
-    }
+
+    const url = data 
+      ? this.endpointReverse({ data, protocol })
+      : this.endpoint({ query, protocol });
 
     const request = await fetch(url);
     const json = await request.json();
     return this.parse({ data: json });
   }
 
-  translateOsmType(osm_type) {
-    if (osm_type === "node") {
-      return "N";
+  translateOsmType(type) {
+    if (type === 'node') {
+      return 'N';
     }
-    if (osm_type === "way") {
-      return "W";
+    if (type === 'way') {
+      return 'W';
     }
-    if (osm_type === "relation") {
-      return "R";
+    if (type === 'relation') {
+      return 'R';
     }
-    return ""; // Unknown
+    return ''; // Unknown
   }
 }

--- a/src/providers/locationIQProvider.js
+++ b/src/providers/locationIQProvider.js
@@ -45,7 +45,7 @@ export default class Provider extends BaseProvider {
     // eslint-disable-next-line no-bitwise
     const protocol = ~location.protocol.indexOf('http') ? location.protocol : 'https:';
 
-    const url = data 
+    const url = data
       ? this.endpointReverse({ data, protocol })
       : this.endpoint({ query, protocol });
 
@@ -55,15 +55,9 @@ export default class Provider extends BaseProvider {
   }
 
   translateOsmType(type) {
-    if (type === 'node') {
-      return 'N';
-    }
-    if (type === 'way') {
-      return 'W';
-    }
-    if (type === 'relation') {
-      return 'R';
-    }
+    if (type === 'node') return 'N';
+    if (type === 'way') return 'W';
+    if (type === 'relation') return 'R';
     return ''; // Unknown
   }
 }

--- a/src/providers/openStreetMapProvider.js
+++ b/src/providers/openStreetMapProvider.js
@@ -13,6 +13,19 @@ export default class Provider extends BaseProvider {
     return `${protocol}//nominatim.openstreetmap.org/search?${paramString}`;
   }
 
+  endpointReverse({ data, protocol } = {}) {
+    const { params } = this.options;
+
+    const paramString = this.getParamString({
+      ...params,
+      format: 'json',
+      osm_id: data.raw.osm_id,
+      osm_type: this.translateOsmType(data.raw.osm_type),
+    });
+
+    return `${protocol}//nominatim.openstreetmap.org/reverse?${paramString}`;
+  }
+
   parse({ data }) {
     return data.map(r => ({
       x: r.lon,
@@ -24,5 +37,32 @@ export default class Provider extends BaseProvider {
       ],
       raw: r,
     }));
+  }
+
+  async search({ query, data }) {
+    // eslint-disable-next-line no-bitwise
+    const protocol = ~location.protocol.indexOf('http') ? location.protocol : 'https:';
+    if (data) {
+      const url = this.endpointReverse({ data, protocol });
+    } else {
+      const url = this.endpoint({ query, protocol });
+    }
+
+    const request = await fetch(url);
+    const json = await request.json();
+    return this.parse({ data: json });
+  }
+
+  translateOsmType(osm_type) {
+    if (osm_type === "node") {
+      return "N";
+    }
+    if (osm_type === "way") {
+      return "W";
+    }
+    if (osm_type === "relation") {
+      return "R";
+    }
+    return ""; // Unknown
   }
 }

--- a/src/providers/openStreetMapProvider.js
+++ b/src/providers/openStreetMapProvider.js
@@ -51,7 +51,7 @@ export default class Provider extends BaseProvider {
 
     const request = await fetch(url);
     const json = await request.json();
-    return this.parse({ data: json });
+    return this.parse({ data: data ? [json] : json });
   }
 
   translateOsmType(type) {

--- a/src/providers/openStreetMapProvider.js
+++ b/src/providers/openStreetMapProvider.js
@@ -19,7 +19,9 @@ export default class Provider extends BaseProvider {
     const paramString = this.getParamString({
       ...params,
       format: 'json',
+      // eslint-disable-next-line camelcase
       osm_id: data.raw.osm_id,
+      // eslint-disable-next-line camelcase
       osm_type: this.translateOsmType(data.raw.osm_type),
     });
 
@@ -42,27 +44,26 @@ export default class Provider extends BaseProvider {
   async search({ query, data }) {
     // eslint-disable-next-line no-bitwise
     const protocol = ~location.protocol.indexOf('http') ? location.protocol : 'https:';
-    if (data) {
-      const url = this.endpointReverse({ data, protocol });
-    } else {
-      const url = this.endpoint({ query, protocol });
-    }
+
+    const url = data 
+      ? this.endpointReverse({ data, protocol })
+      : this.endpoint({ query, protocol });
 
     const request = await fetch(url);
     const json = await request.json();
     return this.parse({ data: json });
   }
 
-  translateOsmType(osm_type) {
-    if (osm_type === "node") {
-      return "N";
+  translateOsmType(type) {
+    if (type === 'node') {
+      return 'N';
     }
-    if (osm_type === "way") {
-      return "W";
+    if (type === 'way') {
+      return 'W';
     }
-    if (osm_type === "relation") {
-      return "R";
+    if (type === 'relation') {
+      return 'R';
     }
-    return ""; // Unknown
+    return ''; // Unknown
   }
 }

--- a/src/providers/openStreetMapProvider.js
+++ b/src/providers/openStreetMapProvider.js
@@ -45,7 +45,7 @@ export default class Provider extends BaseProvider {
     // eslint-disable-next-line no-bitwise
     const protocol = ~location.protocol.indexOf('http') ? location.protocol : 'https:';
 
-    const url = data 
+    const url = data
       ? this.endpointReverse({ data, protocol })
       : this.endpoint({ query, protocol });
 
@@ -55,15 +55,9 @@ export default class Provider extends BaseProvider {
   }
 
   translateOsmType(type) {
-    if (type === 'node') {
-      return 'N';
-    }
-    if (type === 'way') {
-      return 'W';
-    }
-    if (type === 'relation') {
-      return 'R';
-    }
+    if (type === 'node') return 'N';
+    if (type === 'way') return 'W';
+    if (type === 'relation') return 'R';
     return ''; // Unknown
   }
 }


### PR DESCRIPTION
See #144 for discussion

I have not tested this, I don't have a proper dev environment to be able to build.

Overview of the changes:
- Add a `data` argument for searching, it should get ignored as-is for other providers, it's only handled by the `search` function overridden for the OSM and LocationIQ providers.
- Add the result from the previous search as the `data` when handling the click on the result list.
- Add the result from the previous search as the `data` when hitting `ENTER` when an item in the result list is selected. For this, I moved up the `const list` to before the check for the `ENTER` key, and I call `select()` on the currently selected item to get the result data.
- Add `endpointReverse` which fills in the params for the `reverse` API endpoint, i.e. the `osm_id` and `osm_type`. The function assumes that data that was passed through `parse` is what's given here, i.e. grabbing the params from `data.raw`. This would probably fail if data from a different provider gets passed in, for example.
- Add a translation function to get the correct `osm_type` argument for the `reverse` API, as the data in the result doesn't match what's expected in the query. I'm making the assumption here that the type can't be anything but the three listed there, because the OSM docs say `[N|W|R]` are the accepted values.
- Add an override for `search` which calls `endpointReverse` instead of `endpoint` if `data` is provided to the search.

I didn't write any additional tests, but I figure that it might make sense to do so, adding a case where a result from a previous test is passed to `search`.