### PR TITLE
Adding option to stop propagation and add autocomplete=none to search form

### DIFF
--- a/src/domUtils.js
+++ b/src/domUtils.js
@@ -4,7 +4,7 @@ export const createElement = (element, classNames = '', parent = null, attribute
   el.className = classNames;
 
   Object.keys(attributes).forEach((key) => {
-    el.setAttribute(key, attributes[key])
+    el.setAttribute(key, attributes[key]);
   });
 
   if (parent) {

--- a/src/domUtils.js
+++ b/src/domUtils.js
@@ -1,7 +1,11 @@
 /* eslint-disable import/prefer-default-export */
-export const createElement = (element, classNames = '', parent = null) => {
+export const createElement = (element, classNames = '', parent = null, attributes = {}) => {
   const el = document.createElement(element);
   el.className = classNames;
+
+  Object.keys(attributes).forEach((key) => {
+    el.setAttribute(key, attributes[key])
+  });
 
   if (parent) {
     parent.appendChild(el);

--- a/src/leafletControl.js
+++ b/src/leafletControl.js
@@ -33,7 +33,7 @@ const defaultOptions = () => ({
   autoComplete: true,
   autoCompleteDelay: 250,
   autoClose: false,
-  keepResult: false
+  keepResult: false,
 });
 
 const wasHandlerEnabled = {};

--- a/src/leafletControl.js
+++ b/src/leafletControl.js
@@ -33,8 +33,7 @@ const defaultOptions = () => ({
   autoComplete: true,
   autoCompleteDelay: 250,
   autoClose: false,
-  keepResult: false,
-  stopClickPropagation: false
+  keepResult: false
 });
 
 const wasHandlerEnabled = {};
@@ -98,6 +97,7 @@ const Control = {
 
     form.addEventListener('mouseenter', e => this.disableHandlers(e), true);
     form.addEventListener('mouseleave', e => this.restoreHandlers(e), true);
+    form.addEventListener('click', e => e.preventDefault(), false);
 
     this.elements = { button, resetButton };
   },

--- a/src/leafletControl.js
+++ b/src/leafletControl.js
@@ -34,6 +34,7 @@ const defaultOptions = () => ({
   autoCompleteDelay: 250,
   autoClose: false,
   keepResult: false,
+  stopClickPropagation: false
 });
 
 const wasHandlerEnabled = {};

--- a/src/searchElement.js
+++ b/src/searchElement.js
@@ -4,7 +4,7 @@ import { ESCAPE_KEY, ENTER_KEY } from './constants';
 export default class SearchElement {
   constructor({ handleSubmit = () => {}, searchLabel = 'search', classNames = {}, stopClickPropagation = false } = {}) {
     const container = createElement('div', ['geosearch', classNames.container].join(' '));
-    const form = createElement('form', ['', classNames.form].join(' '), container);
+    const form = createElement('form', ['', classNames.form].join(' '), container, { 'autocomplete': 'none' });
     const input = createElement('input', ['glass', classNames.input].join(' '), form);
 
     input.type = 'text';

--- a/src/searchElement.js
+++ b/src/searchElement.js
@@ -2,7 +2,7 @@ import { createElement, addClassName, removeClassName } from './domUtils';
 import { ESCAPE_KEY, ENTER_KEY } from './constants';
 
 export default class SearchElement {
-  constructor({ handleSubmit = () => {}, searchLabel = 'search', classNames = {}, stopClickPropagation = false } = {}) {
+  constructor({ handleSubmit = () => {}, searchLabel = 'search', classNames = {} } = {}) {
     const container = createElement('div', ['geosearch', classNames.container].join(' '));
     const form = createElement('form', ['', classNames.form].join(' '), container, { 'autocomplete': 'none' });
     const input = createElement('input', ['glass', classNames.input].join(' '), form);
@@ -15,9 +15,6 @@ export default class SearchElement {
     input.addEventListener('keypress', (e) => { this.onKeyPress(e); }, false);
     input.addEventListener('focus', (e) => { this.onFocus(e); }, false);
     input.addEventListener('blur', (e) => { this.onBlur(e); }, false);
- 
-    if(stopClickPropagation)
-      form.addEventListener('click', function (e) { event.stopPropagation(); }, false);
 
     this.elements = { container, form, input };
     this.handleSubmit = handleSubmit;

--- a/src/searchElement.js
+++ b/src/searchElement.js
@@ -2,7 +2,7 @@ import { createElement, addClassName, removeClassName } from './domUtils';
 import { ESCAPE_KEY, ENTER_KEY } from './constants';
 
 export default class SearchElement {
-  constructor({ handleSubmit = () => {}, searchLabel = 'search', classNames = {} } = {}) {
+  constructor({ handleSubmit = () => {}, searchLabel = 'search', classNames = {}, stopClickPropagation = false } = {}) {
     const container = createElement('div', ['geosearch', classNames.container].join(' '));
     const form = createElement('form', ['', classNames.form].join(' '), container);
     const input = createElement('input', ['glass', classNames.input].join(' '), form);
@@ -15,6 +15,9 @@ export default class SearchElement {
     input.addEventListener('keypress', (e) => { this.onKeyPress(e); }, false);
     input.addEventListener('focus', (e) => { this.onFocus(e); }, false);
     input.addEventListener('blur', (e) => { this.onBlur(e); }, false);
+ 
+    if(stopClickPropagation)
+      form.addEventListener('click', function (e) { event.stopPropagation(); }, false);
 
     this.elements = { container, form, input };
     this.handleSubmit = handleSubmit;

--- a/src/searchElement.js
+++ b/src/searchElement.js
@@ -4,7 +4,7 @@ import { ESCAPE_KEY, ENTER_KEY } from './constants';
 export default class SearchElement {
   constructor({ handleSubmit = () => {}, searchLabel = 'search', classNames = {} } = {}) {
     const container = createElement('div', ['geosearch', classNames.container].join(' '));
-    const form = createElement('form', ['', classNames.form].join(' '), container, { 'autocomplete': 'none' });
+    const form = createElement('form', ['', classNames.form].join(' '), container, { autocomplete: 'none' });
     const input = createElement('input', ['glass', classNames.input].join(' '), form);
 
     input.type = 'text';


### PR DESCRIPTION
Hi, 

I have added an option "stopClickPropagation" to stop propagation on click to allow people to be able to use something like map.on('click', function() { alert("Click") }); and not have it trigger on clicking the search form. 

I have also added autocomplete="none" to the search form due to web browsers trying to autocomplete and hiding the search results.

Not sure if you want these commits but I thought I would chuck them your way :)