### PR TITLE
Fixes #161: Moving OSM provider to HTTPS

### DIFF
--- a/src/providers/openStreetMapProvider.js
+++ b/src/providers/openStreetMapProvider.js
@@ -10,7 +10,7 @@ export default class Provider extends BaseProvider {
       q: query,
     });
 
-    return `${protocol}//nominatim.openstreetmap.org/search?${paramString}`;
+    return `https://nominatim.openstreetmap.org/search?${paramString}`;
   }
 
   endpointReverse({ data, protocol } = {}) {


### PR DESCRIPTION
Since OSM/Nominatim has moved to HTTPS only (with a 302 redirect from HTTP) the request no longer works from http apllications.