### PR TITLE
Fix error being thrown when enter is pressed before any results are rendered

### DIFF
--- a/src/resultList.js
+++ b/src/resultList.js
@@ -12,6 +12,7 @@ export default class ResultList {
 
     container.addEventListener('click', this.onClick, true);
     this.elements = { container, resultItem };
+    this.results = [];
   }
 
   render(results = []) {


### PR DESCRIPTION
To reproduce the bug:

1. Go to https://smeijer.github.io/leaflet-geosearch/#google
2. Type any place name to the geocoding input and hit Enter before the results are rendered
3. Open the console to see the error (Uncaught TypeError: Cannot read property '-1' of undefined)

This bug happens because the leaflet control tries to select a result before the `this.resultList` in `src/resultList.js` isn't initialized yet. This pull request initializes `this.resultList` in the constructor. 