### PR TITLE
fix the runtime error due to accessing non-initialized this.results in src/resultList.js

### DIFF
--- a/src/leafletControl.js
+++ b/src/leafletControl.js
@@ -189,8 +189,10 @@ const Control = {
     const list = this.resultList;
 
     if (event.keyCode === ENTER_KEY) {
-      const item = list.select(list.selected);
-      this.onSubmit({ query: input.value, data: item });
+      if (list.selected !== -1) {
+        const item = list.select(list.selected);
+        this.onSubmit({ query: input.value, data: item });
+      }
       return;
     }
 


### PR DESCRIPTION
The error happens when ENTER key is pressed in the search bar before resultList.render() is called.
This patch prevents resultList.select(index) from being called when the selected result's index is -1
(i.e. when the result item is not selected yet).

How to reproduce the error:
  1. Open https://smeijer.github.io/leaflet-geosearch/#openstreetmap
  2. Open dev console.
  3. Focus on the search bar input and press Enter key.
![error-reproduction-leaflet-geosearch](https://user-images.githubusercontent.com/38098238/47266592-eaf16500-d562-11e8-89fd-e285a8e741b9.png)
