### PR TITLE
Fix for google provider test

### DIFF
--- a/src/providers/__tests__/googleProvider.spec.js
+++ b/src/providers/__tests__/googleProvider.spec.js
@@ -1,7 +1,7 @@
 import test from 'ava';
 import Provider from '../googleProvider';
 
-test('Can fetch results with Google Provider', async (t) => {
+async function testFetch(t) {
   const provider = new Provider({
     params: {
       key: process.env.GOOGLE_API_KEY,
@@ -18,9 +18,9 @@ test('Can fetch results with Google Provider', async (t) => {
   t.true(result.bounds[1][0] > result.bounds[1][1]);
   t.true(result.bounds[0][0] < result.bounds[1][0]);
   t.true(result.bounds[0][1] < result.bounds[1][1]);
-});
+}
 
-test('Can get localized results', async (t) => {
+async function testLocalizedResults(t) {
   const provider = new Provider({
     params: {
       key: process.env.GOOGLE_API_KEY,
@@ -30,4 +30,13 @@ test('Can get localized results', async (t) => {
 
   const results = await provider.search({ query: 'leeuwarden' });
   t.is(results[0].label, 'Leeuwarden, Nederland');
-});
+}
+
+if (process.env.GOOGLE_API_KEY) {
+  test('Can fetch results with Google Provider', testFetch);
+  test('Can get localized results', testLocalizedResults);
+}
+else {
+  test.skip('Can fetch results with Google Provider', testFetch);
+  test.skip('Can get localized results', testLocalizedResults);
+}

--- a/src/providers/__tests__/googleProvider.spec.js
+++ b/src/providers/__tests__/googleProvider.spec.js
@@ -2,7 +2,11 @@ import test from 'ava';
 import Provider from '../googleProvider';
 
 test('Can fetch results with Google Provider', async (t) => {
-  const provider = new Provider();
+  const provider = new Provider({
+    params: {
+      key: process.env.GOOGLE_API_KEY,
+    },
+  });
 
   const results = await provider.search({ query: 'netherlands' });
   const result = results[0];
@@ -19,23 +23,11 @@ test('Can fetch results with Google Provider', async (t) => {
 test('Can get localized results', async (t) => {
   const provider = new Provider({
     params: {
+      key: process.env.GOOGLE_API_KEY,
       language: 'nl',
     },
   });
 
   const results = await provider.search({ query: 'leeuwarden' });
   t.is(results[0].label, 'Leeuwarden, Nederland');
-});
-
-test.skip('Can fetch results with API Key', async (t) => {
-  const provider = new Provider({
-    params: {
-      key: process.env.GOOGLE_API_KEY,
-    },
-  });
-
-  const results = await provider.search({ query: 'nederland' });
-  const result = results[0];
-
-  t.truthy(result.label);
 });


### PR DESCRIPTION
API Key is required now
- add an API key from env to provider in tests
- remove a test, related to fetching with API key
(fetching with key by default)