### PR TITLE
feat: add leaflet control option to not update map view

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@ new GeoSearchControl({
   autoClose: false, // optional: true|false  - default false
   searchLabel: 'Enter address', // optional: string      - default 'Enter address'
   keepResult: false, // optional: true|false  - default false
+  updateMap: true, // optional: true|false  - default true
 });
 ```
 
@@ -246,6 +247,8 @@ only panned.
 `autoClose` closes the result list if a result is selected by click/enter.
 
 `keepResult` is used to keep the selected result in the search field. This prevents markers to disappear while using the `autoClose` feature.
+
+`updateMap` controls whether or not the map re-centers on the selection.
 
 **Events**
 

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -49,6 +49,7 @@ const defaultOptions: Omit<SearchControlProps, 'provider'> = {
   autoCompleteDelay: 250,
   autoClose: false,
   keepResult: false,
+  updateMap: true,
 };
 
 const UNINITIALIZED_ERR =
@@ -96,6 +97,7 @@ interface SearchControlProps {
   maxSuggestions: number;
   autoClose: boolean;
   keepResult: boolean;
+  updateMap: boolean;
 }
 
 export type SearchControlOptions = Partial<SearchControlProps> & {
@@ -354,7 +356,7 @@ const Control: SearchControl = {
   },
 
   showResult(result, query) {
-    const { autoClose } = this.options;
+    const { autoClose, updateMap } = this.options;
 
     // @ts-ignore
     const markers = Object.keys(this.markers._layers);
@@ -364,7 +366,10 @@ const Control: SearchControl = {
     }
 
     const marker = this.addMarker(result, query);
-    this.centerMap(result);
+
+    if (updateMap) {
+      this.centerMap(result);
+    }
 
     this.map.fireEvent('geosearch/showlocation', {
       location: result,


### PR DESCRIPTION
@smeijer & maintainers I have a Pull Request for your review.

For the Leaflet SearchControl I've added an `updateMap` option to not center the map at all.

This is a very useful option because it works well in conjunction with the `geosearch/showlocation` event. It frees up developers to use the convenience of the built-in Leaflet Control without restricting them to forced map centering.

I have a use-case for an app I'm building where instead of moving the map to the specific location searched, I will use the location from the event to instead zoom to the county that the location is in. This feature would give me the freedom to use your Leaflet Control while writing my own map centering.

I hope you like this feature and please let me know if there's anything I can/should change. I picked "updateMap" as the option name but if there's a better name for that option then please let me know and/or edit.