### PR TITLE
fix: use marker layer instead of layer key

### DIFF
--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -356,10 +356,8 @@ const Control: SearchControl = {
   showResult(result, query) {
     const { autoClose } = this.options;
 
-    // @ts-ignore
-    const markers = Object.keys(this.markers._layers);
+    const markers = this.markers.getLayers();
     if (markers.length >= this.options.maxMarkers) {
-      // @ts-ignore
       this.markers.removeLayer(markers[0]);
     }
 


### PR DESCRIPTION
**Problem:**
current code fails on leaflet 1.7+ when you try to search more than once with error `leaflet-src.js:69 Uncaught (in promise) TypeError: Cannot create property '_leaflet_id' on string '582'` because [now](https://github.com/Leaflet/Leaflet/pull/6998/files) leaflet doesn't support number-like strings. It was missed since TypeScript was suppressed here.

**Proposed changes:**
1. use `getLayers` function instead of a private field
2. Remove ts suppression

