### PR TITLE
feat: add MapBox provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -10,5 +10,6 @@ export { default as HereProvider } from './providers/hereProvider';
 export { default as LocationIQProvider } from './providers/locationIQProvider';
 export { default as OpenCageProvider } from './providers/openCageProvider';
 export { default as OpenStreetMapProvider } from './providers/openStreetMapProvider';
+export { default as MapBoxProvider } from './providers/mapBoxProvider';
 
 export { default as JsonProvider } from './providers/provider';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,5 +5,6 @@ export { default as GoogleProvider } from './googleProvider';
 export { default as LocationIQProvider } from './locationIQProvider';
 export { default as OpenCageProvider } from './openCageProvider';
 export { default as OpenStreetMapProvider } from './openStreetMapProvider';
+export { default as MapBoxProvider } from './mapBoxProvider';
 
 export { default as Provider } from './provider';

--- a/src/providers/mapBoxProvider.ts
+++ b/src/providers/mapBoxProvider.ts
@@ -12,6 +12,7 @@ export type RequestResult = {
 export interface RawResult {
   center: [string, string];
   text: string;
+  place_name: string;
   bbox: [string, string, string, string];
 }
 
@@ -54,7 +55,7 @@ export default class MapBoxProvider extends AbstractProvider<
       return {
         x: Number(r.center[0]),
         y: Number(r.center[1]),
-        label: r.text,
+        label: r.place_name ? r.place_name : r.text,
         bounds,
         raw: r,
       };

--- a/src/providers/mapBoxProvider.ts
+++ b/src/providers/mapBoxProvider.ts
@@ -1,0 +1,63 @@
+import AbstractProvider, {
+  EndpointArgument,
+  ParseArgument,
+  ProviderOptions,
+  SearchResult,
+  BoundsTuple,
+} from './provider';
+
+export type RequestResult = {
+  features: RawResult[];
+};
+export interface RawResult {
+  center: [string, string];
+  text: string;
+  bbox: [string, string, string, string];
+}
+
+export type MapBoxProviderOptions = {
+  searchUrl?: string;
+  reverseUrl?: string;
+} & ProviderOptions;
+
+export default class MapBoxProvider extends AbstractProvider<
+  RequestResult,
+  RawResult
+> {
+  searchUrl: string;
+
+  constructor(options: MapBoxProviderOptions = {}) {
+    super(options);
+
+    const host = 'https://a.tiles.mapbox.com';
+    this.searchUrl = options.searchUrl || `${host}/v4/geocode/mapbox.places/`;
+  }
+
+  endpoint({ query }: EndpointArgument): string {
+    return this.getUrl(`${this.searchUrl}${query}.json`);
+  }
+
+  parse(response: ParseArgument<RequestResult>): SearchResult<RawResult>[] {
+    const records = Array.isArray(response.data.features)
+      ? response.data.features
+      : [];
+
+    return records.map((r) => {
+      let bounds = null;
+      if (r.bbox) {
+        bounds = [
+          [parseFloat(r.bbox[1]), parseFloat(r.bbox[0])], // s, w
+          [parseFloat(r.bbox[3]), parseFloat(r.bbox[2])], // n, e
+        ] as BoundsTuple;
+      }
+
+      return {
+        x: Number(r.center[0]),
+        y: Number(r.center[1]),
+        label: r.text,
+        bounds,
+        raw: r,
+      };
+    });
+  }
+}


### PR DESCRIPTION
Added new MapBox provider for GeoSearch.

example of usage:
`      const provider = new MapBoxProvider({
        params: {
          access_token:
            "ACCESS_TOKEN",
        },
      });`

An access token can be obtained here:
https://docs.mapbox.com/accounts/overview/tokens/