### PR TITLE
feat: add option to format results

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # Leaflet.GeoSearch
+
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+
 [![All Contributors](https://img.shields.io/badge/all_contributors-39-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 **Demo and Docs: [smeijer.github.io/leaflet-geosearch](https://smeijer.github.io/leaflet-geosearch)**
@@ -216,7 +219,8 @@ new GeoSearchControl({
     icon: new L.Icon.Default(),
     draggable: false,
   },
-  popupFormat: ({ query, result }) => result.label, // optional: function    - default returns result label
+  popupFormat: ({ query, result }) => result.label, // optional: function    - default returns result label,
+  resultFormat: ({ result }) => result.label, // optional: function    - default returns result label
   maxMarkers: 1, // optional: number      - default 1
   retainZoomLevel: false, // optional: true|false  - default false
   animateZoom: true, // optional: true|false  - default true
@@ -233,6 +237,8 @@ open a popup with the location text.
 `marker` can be set to any instance of a (custom) `L.Icon`.
 
 `popupFormat` is callback function for displaying text on popup.
+
+`resultFormat` is callback function for modifying the search result texts (e. g. in order to hide address components or change its ordering).
 
 `maxMarker` determines how many last results are kept in memory. Default 1, but
 perhaps you want to show the last `x` results when searching for new queries as
@@ -348,6 +354,7 @@ Thanks goes to these wonderful people ([emoji key](https://allcontributors.org/d
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@mrsimpson/leaflet-geosearch",
-  "version": "3.1.0-mrsimpson-2",
+  "name": "leaflet-geosearch",
+  "version": "3.1.0",
   "description": "Adds support for address lookup (a.k.a. geocoding / geoseaching) to Leaflet.",
   "publishConfig": {
     "tag": "latest"
@@ -98,9 +98,7 @@
     "ts-jest": "^25.3.1",
     "typescript": "^3.8.3"
   },
-  "dependencies": {
-    "leaflet": "^1.6.0"
-  },
+  "dependencies": {},
   "optionalDependencies": {
     "leaflet": "^1.6.0"
   },
@@ -108,10 +106,5 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
-  },
-  "directories": {
-    "doc": "docs",
-    "lib": "lib",
-    "test": "test"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "leaflet-geosearch",
-  "version": "3.1.0",
+  "name": "@mrsimpson/leaflet-geosearch",
+  "version": "3.1.0-mrsimpson-2",
   "description": "Adds support for address lookup (a.k.a. geocoding / geoseaching) to Leaflet.",
   "publishConfig": {
     "tag": "latest"
@@ -98,7 +98,9 @@
     "ts-jest": "^25.3.1",
     "typescript": "^3.8.3"
   },
-  "dependencies": {},
+  "dependencies": {
+    "leaflet": "^1.6.0"
+  },
   "optionalDependencies": {
     "leaflet": "^1.6.0"
   },
@@ -106,5 +108,10 @@
     "hooks": {
       "pre-commit": "lint-staged"
     }
+  },
+  "directories": {
+    "doc": "docs",
+    "lib": "lib",
+    "test": "test"
   }
 }

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -25,6 +25,7 @@ const defaultOptions: Omit<SearchControlProps, 'provider'> = {
   showMarker: true,
   showPopup: false,
   popupFormat: ({ result }) => `${result.label}`,
+  resultFormat: ({ result }) => `${result.label}`,
   marker: {
     icon: L && L.Icon ? new L.Icon.Default() : undefined,
     draggable: false,
@@ -74,6 +75,8 @@ interface SearchControlProps {
     query: Selection;
     result: SearchResult<T>;
   }): string;
+
+  resultFormat<T = any>(args: { result: SearchResult<T> }): string;
 
   searchLabel: string;
   notFoundMessage: string;
@@ -339,7 +342,7 @@ const Control: SearchControl = {
     if (query.length) {
       let results = await provider!.search({ query });
       results = results.slice(0, this.options.maxSuggestions);
-      this.resultList.render(results);
+      this.resultList.render(results, this.options.resultFormat);
     } else {
       this.resultList.clear();
     }

--- a/src/resultList.ts
+++ b/src/resultList.ts
@@ -29,13 +29,13 @@ export default class ResultList {
     this.resultItem = createElement<HTMLDivElement>('div', cx(classNames.item));
   }
 
-  render(results: SearchResult[] = []): void {
+  render(results: SearchResult[] = [], resultFormater: Function): void {
     this.clear();
 
     results.forEach((result, idx) => {
       const child = this.resultItem.cloneNode(true) as HTMLDivElement;
       child.setAttribute('data-key', `${idx}`);
-      child.innerHTML = result.label;
+      child.innerHTML = resultFormater(result);
       this.container.appendChild(child);
     });
 

--- a/src/resultList.ts
+++ b/src/resultList.ts
@@ -29,13 +29,13 @@ export default class ResultList {
     this.resultItem = createElement<HTMLDivElement>('div', cx(classNames.item));
   }
 
-  render(results: SearchResult[] = [], resultFormater: Function): void {
+  render(results: SearchResult[] = [], resultFormat: Function): void {
     this.clear();
 
     results.forEach((result, idx) => {
       const child = this.resultItem.cloneNode(true) as HTMLDivElement;
       child.setAttribute('data-key', `${idx}`);
-      child.innerHTML = resultFormater(result);
+      child.innerHTML = resultFormat(result);
       this.container.appendChild(child);
     });
 


### PR DESCRIPTION
# Motivation

Some search providers, especially OSM, return the address search results in a not very common order.
E. g. the house number is returned in the first position of the label, which is very uncommon in German.

# Changes done

This PR introduces a callback function which is executed in order to manipulate the search result label.

# Caveats

As the query is currently not available in the result list, it could not be propagated to the callback function.
Adding this would have increased the PR which I wanted to avoid.

# How it looks like

## Before

Provider OSM
<img width="900" alt="without-callback" src="https://user-images.githubusercontent.com/17176678/101814589-a3513d00-3b1e-11eb-9e55-3549884992ab.png">

## Afterwards

with callback injected
```javascript
resultFormat: (result)=>{
          if(result.label.match(/^\d+,/)){
            // swap house no and street
            const components = result.label.split(',').map(s=>s.trim())
            const houseNo = components[0]
            components[0] = components[1]
            components[1] = houseNo
            return `${components.slice(0,2).join(' ')}, ${components.slice(2, components.length).join(',  ')}`
          }
          return result.label
          },
```
<img width="820" alt="with-callback" src="https://user-images.githubusercontent.com/17176678/101814744-dabfe980-3b1e-11eb-9e0b-ce7fc8a28751.png">
