### PR TITLE
fix: support retainZoomLevel for providers not including bounds

### DIFF
--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -432,7 +432,11 @@ const Control: SearchControl = {
       ? resultBounds
       : this.markers.getBounds();
 
-    if (!retainZoomLevel && resultBounds.isValid()) {
+    if(!retainZoomLevel && resultBounds.isValid() && !result.bounds){
+      this.map.setView(bounds.getCenter(), this.getZoom(), {
+        animate: animateZoom,
+      });
+    } else if (!retainZoomLevel && resultBounds.isValid()) {
       this.map.fitBounds(bounds, { animate: animateZoom });
     } else {
       this.map.setView(bounds.getCenter(), this.getZoom(), {

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -432,7 +432,7 @@ const Control: SearchControl = {
       ? resultBounds
       : this.markers.getBounds();
 
-    if(!retainZoomLevel && resultBounds.isValid() && !result.bounds){
+    if (!retainZoomLevel && resultBounds.isValid() && !result.bounds) {
       this.map.setView(bounds.getCenter(), this.getZoom(), {
         animate: animateZoom,
       });


### PR DESCRIPTION
Hello,
Whether or not this is actually needed or how it is implemented depends on the intended functionality, but I ran into an issue where it was impossible for me to get my zoomLevel option to affect anything when creating a new instance of GeoSearchControl. This was because I was using the HereProvider, and HereAPI does not return bounds. The provider returns null for result.bounds. Because result.bounds is null, this causes the first if statement in SearchControl.centerMap() to always evaluate to true, which disregards the zoomLevel option and uses const resultBounds, which in the case of hereAPI always evaluates to 'new L.LatLng(result.y, result.x).toBounds(10)' because result.bounds is null with HereProvider.

This effectively makes it so that you can never go by options.zoomLevel because the only way to miss the first if statement is to set retainZoomLevel = true or to have invalid resultBounds, which will cause SearchControl.getZoom() to use the current zoom level anyways: 
`return retainZoomLevel ? this.map.getZoom() : zoomLevel;`

My proposed solution adds another if statement at the beginning of SearchControl.centerMap() which executes the same code in contained in its else block if results.bounds and retainZoomLevel are both falsey.

I am probably missing some use cases, but I just wanted to help out anyway with your great library! Thank you!