### PR TITLE
feat: add option for custom "not found message"

### DIFF
--- a/assets/css/leaflet.css
+++ b/assets/css/leaflet.css
@@ -212,6 +212,10 @@
   border-right: none;
 }
 
+.leaflet-bar-notfound {
+  font-style: italic;
+}
+
 .leaflet-control-geosearch a.reset {
   color: black;
   font-weight: bold;

--- a/docs/leaflet-control.mdx
+++ b/docs/leaflet-control.mdx
@@ -49,7 +49,9 @@ map.addControl(searchControl);
 <Playground>
   <Map
     provider="OpenStreetMap"
-    controlOptions={{ notFoundMessage: 'No errors founds' }}
+    controlOptions={{
+      notFoundMessage: 'Sorry, that address could not be found.',
+    }}
   />
 </Playground>
 
@@ -57,7 +59,7 @@ map.addControl(searchControl);
 import { SearchControl, OpenStreetMapProvider } from 'leaflet-geosearch';
 
 const searchControl = new SearchControl({
-  notFoundMessage: 'No errors founds',
+  notFoundMessage: 'Sorry, that address could not be found.',
   provider: new OpenStreetMapProvider(),
 });
 

--- a/docs/leaflet-control.mdx
+++ b/docs/leaflet-control.mdx
@@ -44,6 +44,27 @@ const searchControl = new SearchControl({
 map.addControl(searchControl);
 ```
 
+## Message if address not found
+
+<Playground>
+  <Map
+    provider="OpenStreetMap"
+    controlOptions={{ notFoundMessage: 'No errors founds' }}
+  />
+</Playground>
+
+```js
+import { SearchControl, OpenStreetMapProvider } from 'leaflet-geosearch';
+
+const searchControl = new SearchControl({
+  notFoundMessage: 'No errors founds',
+  provider: new OpenStreetMapProvider(),
+});
+
+map.addControl(searchControl);
+``
+
 ## Properties
 
 <Props of={SearchControl} />
+```

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -45,6 +45,8 @@ const defaultOptions: Omit<SearchControlProps, 'provider'> = {
     msgbox: 'leaflet-bar message',
     form: '',
     input: '',
+    resultlist: '',
+    item: '',
   },
   autoComplete: true,
   autoCompleteDelay: 250,
@@ -93,6 +95,8 @@ interface SearchControlProps {
     msgbox: string;
     form: string;
     input: string;
+    resultlist: string;
+    item: string;
   };
 
   autoComplete: boolean;
@@ -205,6 +209,11 @@ const Control: SearchControl = {
           this.searchElement.input.value = result.label;
           this.onSubmit({ query: result.label, data: result });
         },
+        classNames: {
+          resultlist: this.classNames.resultlist,
+          item: this.classNames.item,
+        },
+        notFoundMessage: this.options.notFoundMessage,
       });
 
       this.searchElement.form.appendChild(this.resultList.container);

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -47,6 +47,7 @@ const defaultOptions: Omit<SearchControlProps, 'provider'> = {
     input: '',
     resultlist: '',
     item: '',
+    notfound: 'leaflet-bar-notfound',
   },
   autoComplete: true,
   autoCompleteDelay: 250,
@@ -97,6 +98,7 @@ interface SearchControlProps {
     input: string;
     resultlist: string;
     item: string;
+    notfound: string;
   };
 
   autoComplete: boolean;
@@ -212,6 +214,7 @@ const Control: SearchControl = {
         classNames: {
           resultlist: this.classNames.resultlist,
           item: this.classNames.item,
+          notfound: this.classNames.notfound,
         },
         notFoundMessage: this.options.notFoundMessage,
       });

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -35,7 +35,7 @@ const defaultOptions: Omit<SearchControlProps, 'provider'> = {
   retainZoomLevel: false,
   animateZoom: true,
   searchLabel: 'Enter address',
-  notFoundMessage: 'Sorry, that address could not be found.',
+  notFoundMessage: '',
   messageHideDelay: 3000,
   zoomLevel: 18,
   classNames: {

--- a/src/resultList.ts
+++ b/src/resultList.ts
@@ -6,6 +6,7 @@ interface ResultListProps {
   classNames?: {
     resultlist?: string;
     item?: string;
+    notfound?: string;
   };
   notFoundMessage?: string;
 }
@@ -14,10 +15,10 @@ export default class ResultList {
   handleClick?: (args: { result: SearchResult }) => void;
   selected = -1;
   results: SearchResult[] = [];
-  notFoundMessage?: string;
 
   container: HTMLDivElement;
   resultItem: HTMLDivElement;
+  notFoundMessage?: HTMLDivElement;
 
   constructor({
     handleClick,
@@ -25,7 +26,14 @@ export default class ResultList {
     notFoundMessage,
   }: ResultListProps) {
     this.handleClick = handleClick;
-    this.notFoundMessage = notFoundMessage;
+    this.notFoundMessage = !!notFoundMessage
+      ? createElement<HTMLDivElement>(
+          'div',
+          cx(classNames.notfound),
+          undefined,
+          { html: notFoundMessage! },
+        )
+      : undefined;
 
     this.container = createElement<HTMLDivElement>(
       'div',
@@ -50,7 +58,7 @@ export default class ResultList {
       addClassName(this.container.parentElement, 'open');
       addClassName(this.container, 'active');
     } else if (!!this.notFoundMessage) {
-      this.container.innerHTML = this.notFoundMessage;
+      this.container.appendChild(this.notFoundMessage);
       addClassName(this.container.parentElement, 'open');
     }
 

--- a/src/resultList.ts
+++ b/src/resultList.ts
@@ -4,25 +4,32 @@ import { SearchResult } from './providers/provider';
 interface ResultListProps {
   handleClick: (args: { result: SearchResult }) => void;
   classNames?: {
-    container?: string;
+    resultlist?: string;
     item?: string;
   };
+  notFoundMessage?: string;
 }
 
 export default class ResultList {
   handleClick?: (args: { result: SearchResult }) => void;
   selected = -1;
   results: SearchResult[] = [];
+  notFoundMessage?: string;
 
   container: HTMLDivElement;
   resultItem: HTMLDivElement;
 
-  constructor({ handleClick, classNames = {} }: ResultListProps) {
+  constructor({
+    handleClick,
+    classNames = {},
+    notFoundMessage,
+  }: ResultListProps) {
     this.handleClick = handleClick;
+    this.notFoundMessage = notFoundMessage;
 
     this.container = createElement<HTMLDivElement>(
       'div',
-      cx('results', classNames.container),
+      cx('results', classNames.resultlist),
     );
     this.container.addEventListener('click', this.onClick, true);
 
@@ -42,6 +49,9 @@ export default class ResultList {
     if (results.length > 0) {
       addClassName(this.container.parentElement, 'open');
       addClassName(this.container, 'active');
+    } else if (!!this.notFoundMessage) {
+      this.container.innerHTML = this.notFoundMessage;
+      addClassName(this.container.parentElement, 'open');
     }
 
     this.results = results;


### PR DESCRIPTION
Fix #282 Display not found message

The properties notFoundMessage isn't used in the lib.
If there are 0 result and the notFountMessage is setted, display the message : 
![image](https://user-images.githubusercontent.com/841858/122768365-d16cc200-d2a3-11eb-957f-c2b8800ea8ba.png)

![image](https://user-images.githubusercontent.com/841858/122768441-e0ec0b00-d2a3-11eb-90bb-667b937bc768.png)


In the resultList class, classNames isn't filled.
Add two new properties in the classNames config : 
- resultlist : class for style the result list
- item : class for style items in the result list
- notfound : class for style when no results (by default use italic tests)


By default, the config option notFoundMessage as the default unused value : 'Sorry, that address could not be found.',
Does change it to default to empty, to keep the same behavior as now ?