### PR TITLE
feat: add Pelias provider

### DIFF
--- a/docs/lib/providers.ts
+++ b/docs/lib/providers.ts
@@ -7,6 +7,7 @@ import {
   LocationIQProvider,
   OpenCageProvider,
   OpenStreetMapProvider,
+  PeliasProvider,
   GeoApiFrProvider,
 } from 'leaflet-geosearch';
 
@@ -36,6 +37,8 @@ export default {
   }),
 
   OpenStreetMap: new OpenStreetMapProvider(),
+
+  Pelias: new PeliasProvider(),
 
   GeoApiFr: new GeoApiFrProvider(),
 };

--- a/docs/providers/pelias.mdx
+++ b/docs/providers/pelias.mdx
@@ -1,0 +1,72 @@
+---
+name: Pelias
+menu: Providers
+route: /providers/pelias
+---
+
+import Playground from '../components/Playground';
+import Map from '../components/Map';
+
+# Pelias Provider
+
+[Pelias][1] is an open-source geocoder powered completely by open data, available freely to everyone.
+
+In order to use this provider you'll need to have your own Pelias server running.
+
+The [Docker][3] repository provides the quickest path to running your own server.
+
+See the [Pelias documentation][2] for more detailed information about the available endpoints and query parameters.
+
+<Playground>
+  <Map provider="Pelias" />
+</Playground>
+
+```js
+import { PeliasProvider } from 'leaflet-geosearch';
+
+// Pelias servers are self-hosted so you'll need to configure the 'options.host' string
+// to identify where requests to your running pelias/api server instance should be sent.
+// note: you SHOULD include the scheme, domain and port but NOT any path or parameters.
+const provider = new PeliasProvider({ host: 'http://localhost:4000' });
+
+// add to leaflet
+import { GeoSearchControl } from 'leaflet-geosearch';
+
+map.addControl(
+  new GeoSearchControl({
+    provider,
+  }),
+);
+```
+
+## Optional parameters
+
+Pelias supports a wide range of number of [optional parameters][4] which can be applied to every request using the `params` object:
+
+```js
+const provider = new PeliasProvider({
+  params: {
+    size: 5, // limit the total number of results returned
+    lang: 'nl', // render results in Dutch
+    'boundary.country': 'NL', // limit search results to the Netherlands
+    layers: 'address,street', // limmit which layers are queried
+  },
+});
+```
+
+Or individually on a per-request basis:
+
+```js
+const results = await provider.search({
+  query: {
+    text: 'example',
+    'focus.point.lat': 1.11, // score results nearer to the focus point higher
+    'focus.point.lon': 2.22,
+  },
+});
+```
+
+[1]: https://github.com/pelias/pelias
+[2]: https://github.com/pelias/documentation
+[3]: https://github.com/pelias/docker
+[4]: https://github.com/pelias/documentation/blob/master/autocomplete.md

--- a/doczrc.js
+++ b/doczrc.js
@@ -25,6 +25,7 @@ export default {
         'LocationIQ',
         'OpenCage',
         'OpenStreetMap',
+        'Pelias',
         'Custom Providers',
       ],
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export { default as HereProvider } from './providers/hereProvider';
 export { default as LocationIQProvider } from './providers/locationIQProvider';
 export { default as OpenCageProvider } from './providers/openCageProvider';
 export { default as OpenStreetMapProvider } from './providers/openStreetMapProvider';
+export { default as PeliasProvider } from './providers/peliasProvider';
 export { default as MapBoxProvider } from './providers/mapBoxProvider';
 export { default as GeoApiFrProvider } from './providers/geoApiFrProvider';
 

--- a/src/providers/__tests__/peliasProvider.spec.js
+++ b/src/providers/__tests__/peliasProvider.spec.js
@@ -1,0 +1,30 @@
+import Provider from '../peliasProvider';
+import fixture from './peliasResponse.json';
+
+describe('PeliasProvider', function () {
+  beforeAll(() => {
+    fetch.mockResponse(async () => ({ body: JSON.stringify(fixture) }));
+  });
+
+  test('Can fetch results', async () => {
+    const provider = new Provider();
+    const results = await provider.search({ query: 'pelias' });
+    expect(results.length).toEqual(9);
+
+    // feature mapping
+    results.forEach((result, i) => {
+      const feat = fixture.features[i];
+      expect(result.label).toBeTruthy();
+      expect(result.x).toEqual(+feat.geometry.coordinates[0]);
+      expect(result.y).toEqual(+feat.geometry.coordinates[1]);
+
+      // bounding box range checks
+      if (feat.bbox) {
+        expect(result.bounds[0][0]).toBeLessThan(result.bounds[1][0]); // south less than north
+        expect(result.bounds[0][1]).toBeLessThan(result.bounds[1][1]); // west less than east
+      } else {
+        expect(result.bounds).toBeFalsy();
+      }
+    });
+  });
+});

--- a/src/providers/__tests__/peliasResponse.json
+++ b/src/providers/__tests__/peliasResponse.json
@@ -1,0 +1,407 @@
+{
+  "geocoding": {
+    "version": "0.2",
+    "attribution": "https://geocode.earth/guidelines",
+    "query": {
+      "text": "pelias",
+      "parser": "pelias",
+      "parsed_text": {
+        "subject": "pelias"
+      },
+      "size": 10,
+      "layers": [
+        "street",
+        "venue",
+        "locality",
+        "neighbourhood",
+        "county",
+        "localadmin",
+        "region",
+        "macrocounty",
+        "country",
+        "macroregion",
+        "borough",
+        "postalcode",
+        "macrohood",
+        "marinearea",
+        "disputed",
+        "dependency",
+        "empire",
+        "continent",
+        "ocean"
+      ],
+      "private": false,
+      "lang": {
+        "name": "English",
+        "iso6391": "en",
+        "iso6393": "eng",
+        "via": "header",
+        "defaulted": false
+      },
+      "querySize": 20
+    },
+    "warnings": [
+      "performance optimization: excluding 'address' layer"
+    ],
+    "engine": {
+      "name": "Pelias",
+      "author": "Mapzen",
+      "version": "1.0"
+    },
+    "timestamp": 1633697770106
+  },
+  "type": "FeatureCollection",
+  "features": [
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          22.999231,
+          39.390835
+        ]
+      },
+      "properties": {
+        "id": "node/2631570458",
+        "gid": "openstreetmap:venue:node/2631570458",
+        "layer": "venue",
+        "source": "openstreetmap",
+        "source_id": "node/2631570458",
+        "country_code": "GR",
+        "name": "Pelias",
+        "accuracy": "point",
+        "country": "Greece",
+        "country_gid": "whosonfirst:country:85633171",
+        "country_a": "GRC",
+        "region": "Thessaly",
+        "region_gid": "whosonfirst:region:85684685",
+        "region_a": "TS",
+        "continent": "Europe",
+        "continent_gid": "whosonfirst:continent:102191581",
+        "label": "Pelias, TS, Greece",
+        "addendum": {
+          "osm": {
+            "website": "www.peliashotel.gr"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.539115,
+          60.908174
+        ]
+      },
+      "properties": {
+        "id": "node/6341953008",
+        "gid": "openstreetmap:venue:node/6341953008",
+        "layer": "venue",
+        "source": "openstreetmap",
+        "source_id": "node/6341953008",
+        "country_code": "NO",
+        "name": "Pelias norsk skadedyrkontroll",
+        "housenumber": "59",
+        "street": "Martensvegen",
+        "postalcode": "2409",
+        "accuracy": "point",
+        "country": "Norway",
+        "country_gid": "whosonfirst:country:85633341",
+        "country_a": "NOR",
+        "region": "Innlandet",
+        "region_gid": "whosonfirst:region:1527947263",
+        "localadmin": "Elverum",
+        "localadmin_gid": "whosonfirst:localadmin:1159297469",
+        "continent": "Europe",
+        "continent_gid": "whosonfirst:continent:102191581",
+        "label": "Pelias norsk skadedyrkontroll, Elverum, Norway",
+        "addendum": {
+          "osm": {
+            "website": "https://pelias.no/",
+            "phone": "+47 33 33 00 00"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          30.981907,
+          -29.939019
+        ]
+      },
+      "properties": {
+        "id": "polyline:24349300",
+        "gid": "openstreetmap:street:polyline:24349300",
+        "layer": "street",
+        "source": "openstreetmap",
+        "source_id": "polyline:24349300",
+        "country_code": "ZA",
+        "name": "Pelias Place",
+        "street": "Pelias Place",
+        "accuracy": "centroid",
+        "country": "South Africa",
+        "country_gid": "whosonfirst:country:85633813",
+        "country_a": "ZAF",
+        "region": "Kwazulu-Natal",
+        "region_gid": "whosonfirst:region:85688911",
+        "region_a": "NL",
+        "county": "eThekwini",
+        "county_gid": "whosonfirst:county:1108730571",
+        "county_a": "ET",
+        "continent": "Africa",
+        "continent_gid": "whosonfirst:continent:102191573",
+        "label": "Pelias Place, NL, South Africa"
+      },
+      "bbox": [
+        30.981231,
+        -29.93952,
+        30.982589,
+        -29.938511
+      ]
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          114.127491,
+          -21.938032
+        ]
+      },
+      "properties": {
+        "id": "polyline:23395079",
+        "gid": "openstreetmap:street:polyline:23395079",
+        "layer": "street",
+        "source": "openstreetmap",
+        "source_id": "polyline:23395079",
+        "country_code": "AU",
+        "name": "Pelias Street",
+        "street": "Pelias Street",
+        "accuracy": "centroid",
+        "country": "Australia",
+        "country_gid": "whosonfirst:country:85632793",
+        "country_a": "AUS",
+        "region": "Western Australia",
+        "region_gid": "whosonfirst:region:85681439",
+        "region_a": "WA",
+        "county": "Exmouth",
+        "county_gid": "whosonfirst:county:102049323",
+        "county_a": "EX",
+        "localadmin": "Exmouth",
+        "localadmin_gid": "whosonfirst:localadmin:404547261",
+        "locality": "Exmouth",
+        "locality_gid": "whosonfirst:locality:101937165",
+        "continent": "Oceania",
+        "continent_gid": "whosonfirst:continent:102191583",
+        "label": "Pelias Street, Exmouth, WA, Australia"
+      },
+      "bbox": [
+        114.124938,
+        -21.93829,
+        114.130027,
+        -21.937611
+      ]
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          123.854135,
+          9.680108
+        ]
+      },
+      "properties": {
+        "id": "polyline:21756510",
+        "gid": "openstreetmap:street:polyline:21756510",
+        "layer": "street",
+        "source": "openstreetmap",
+        "source_id": "polyline:21756510",
+        "country_code": "PH",
+        "name": "F. Pelias",
+        "street": "F. Pelias",
+        "accuracy": "centroid",
+        "country": "Philippines",
+        "country_gid": "whosonfirst:country:85632509",
+        "country_a": "PHL",
+        "region": "Bohol",
+        "region_gid": "whosonfirst:region:85675933",
+        "region_a": "BO",
+        "county": "Tagbilaran City",
+        "county_gid": "whosonfirst:county:1108699607",
+        "continent": "Asia",
+        "continent_gid": "whosonfirst:continent:102191569",
+        "label": "F. Pelias, BO, Philippines"
+      },
+      "bbox": [
+        123.853164,
+        9.679871,
+        123.855064,
+        9.680231
+      ]
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -61.31722,
+          -66.05479
+        ]
+      },
+      "properties": {
+        "id": "6623050",
+        "gid": "geonames:venue:6623050",
+        "layer": "venue",
+        "source": "geonames",
+        "source_id": "6623050",
+        "country_code": "AQ",
+        "name": "Pelias Bluff",
+        "accuracy": "point",
+        "country": "Antarctica",
+        "country_gid": "whosonfirst:country:85632715",
+        "country_a": "ATA",
+        "continent": "Antarctica",
+        "continent_gid": "whosonfirst:continent:102191579",
+        "label": "Pelias Bluff, Antarctica",
+        "addendum": {
+          "geonames": {
+            "feature_code": "SLP"
+          }
+        }
+      }
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          -4.070734,
+          43.423036
+        ]
+      },
+      "properties": {
+        "id": "polyline:10453562",
+        "gid": "openstreetmap:street:polyline:10453562",
+        "layer": "street",
+        "source": "openstreetmap",
+        "source_id": "polyline:10453562",
+        "country_code": "ES",
+        "name": "Calle Las Pelías",
+        "street": "Calle Las Pelías",
+        "accuracy": "centroid",
+        "country": "Spain",
+        "country_gid": "whosonfirst:country:85633129",
+        "country_a": "ESP",
+        "macroregion": "Cantabria",
+        "macroregion_gid": "whosonfirst:macroregion:404227371",
+        "region": "Cantabria",
+        "region_gid": "whosonfirst:region:85682833",
+        "region_a": "CB",
+        "localadmin": "Suances",
+        "localadmin_gid": "whosonfirst:localadmin:404342231",
+        "continent": "Europe",
+        "continent_gid": "whosonfirst:continent:102191581",
+        "label": "Calle Las Pelías, Suances, CB, Spain"
+      },
+      "bbox": [
+        -4.072311,
+        43.420791,
+        -4.06891,
+        43.425346
+      ]
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          101.73333,
+          5.7
+        ]
+      },
+      "properties": {
+        "id": "1309815263",
+        "gid": "whosonfirst:locality:1309815263",
+        "layer": "locality",
+        "source": "whosonfirst",
+        "source_id": "1309815263",
+        "country_code": "MY",
+        "name": "Kampong Pelias",
+        "accuracy": "centroid",
+        "country": "Malaysia",
+        "country_gid": "whosonfirst:country:85632739",
+        "country_a": "MYS",
+        "region": "Kelantan",
+        "region_gid": "whosonfirst:region:85675145",
+        "region_a": "KTN",
+        "county": "Jeli",
+        "county_gid": "whosonfirst:county:890490101",
+        "locality": "Kampong Pelias",
+        "locality_gid": "whosonfirst:locality:1309815263",
+        "continent": "Asia",
+        "continent_gid": "whosonfirst:continent:102191569",
+        "label": "Kampong Pelias, KTN, Malaysia",
+        "addendum": {
+          "concordances": {
+            "gn:id": 1765795
+          }
+        }
+      },
+      "bbox": [
+        101.71333,
+        5.68,
+        101.75333,
+        5.72
+      ]
+    },
+    {
+      "type": "Feature",
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          101.73333,
+          5.7
+        ]
+      },
+      "properties": {
+        "id": "1751307",
+        "gid": "geonames:venue:1751307",
+        "layer": "venue",
+        "source": "geonames",
+        "source_id": "1751307",
+        "country_code": "MY",
+        "name": "Sungai Pelias",
+        "accuracy": "point",
+        "country": "Malaysia",
+        "country_gid": "whosonfirst:country:85632739",
+        "country_a": "MYS",
+        "region": "Kelantan",
+        "region_gid": "whosonfirst:region:85675145",
+        "region_a": "KTN",
+        "county": "Jeli",
+        "county_gid": "whosonfirst:county:890490101",
+        "county_a": "JE",
+        "continent": "Asia",
+        "continent_gid": "whosonfirst:continent:102191569",
+        "label": "Sungai Pelias, KTN, Malaysia",
+        "addendum": {
+          "geonames": {
+            "feature_code": "STM"
+          }
+        }
+      }
+    }
+  ],
+  "bbox": [
+    -61.31722,
+    -66.05479,
+    123.855064,
+    60.908174
+  ]
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -5,6 +5,7 @@ export { default as GoogleProvider } from './googleProvider';
 export { default as LocationIQProvider } from './locationIQProvider';
 export { default as OpenCageProvider } from './openCageProvider';
 export { default as OpenStreetMapProvider } from './openStreetMapProvider';
+export { default as PeliasProvider } from './peliasProvider';
 export { default as MapBoxProvider } from './mapBoxProvider';
 export { default as GeoApiFrProvider } from './geoApiFrProvider';
 

--- a/src/providers/peliasProvider.ts
+++ b/src/providers/peliasProvider.ts
@@ -1,0 +1,164 @@
+import AbstractProvider, {
+  EndpointArgument,
+  ParseArgument,
+  ProviderOptions,
+  RequestType,
+  SearchResult,
+} from './provider';
+
+export interface RequestResult {
+  geocoding: object;
+  features: RawResult[];
+}
+
+export type PeliasProviderOptions = {
+  host?: string;
+} & ProviderOptions;
+
+export interface RawResult {
+  type: 'Feature';
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number];
+  };
+  bbox?: [number, number, number, number];
+  properties: {
+    id: string;
+    source_id: string;
+    gid: string;
+
+    layer: string;
+    source: string;
+
+    label: string;
+    name: string;
+
+    accuracy: 'centroid' | 'point';
+    confidence?: number;
+    match_type?: 'exact' | 'interpolated' | 'fallback';
+
+    borough?: string;
+    borough_a?: string;
+    borough_gid?: string;
+    continent?: string;
+    continent_a?: string;
+    continent_gid?: string;
+    country?: string;
+    country_a?: string;
+    country_gid?: string;
+    county?: string;
+    county_a?: string;
+    county_gid?: string;
+    dependency?: string;
+    dependency_a?: string;
+    dependency_gid?: string;
+    empire?: string;
+    empire_a?: string;
+    empire_gid?: string;
+    localadmin?: string;
+    localadmin_a?: string;
+    localadmin_gid?: string;
+    locality?: string;
+    locality_a?: string;
+    locality_gid?: string;
+    macrocounty?: string;
+    macrocounty_a?: string;
+    macrocounty_gid?: string;
+    macroregion?: string;
+    macroregion_a?: string;
+    macroregion_gid?: string;
+    marinearea?: string;
+    marinearea_a?: string;
+    marinearea_gid?: string;
+    neighbourhood?: string;
+    neighbourhood_a?: string;
+    neighbourhood_gid?: string;
+    ocean?: string;
+    ocean_a?: string;
+    ocean_gid?: string;
+    postalcode?: string;
+    postalcode_a?: string;
+    postalcode_gid?: string;
+    region?: string;
+    region_a?: string;
+    region_gid?: string;
+
+    street?: string;
+    housenumber?: string;
+
+    addendum?: any;
+  };
+}
+
+export default class PeliasProvider extends AbstractProvider<
+  RequestResult,
+  RawResult
+> {
+  // Pelias servers are self-hosted so you'll need to configure the 'options.host' string
+  // to identify where requests to your running pelias/api server instance should be sent.
+  // note: you SHOULD include the scheme, domain and port but NOT any path or parameters.
+  // If you're using the Docker setup (https://github.com/pelias/docker)
+  // then the default host of 'http://localhost:4000' will work out of the box.
+  host: string;
+
+  constructor(options: PeliasProviderOptions = {}) {
+    super(options);
+    this.host = options.host || 'http://localhost:4000';
+  }
+
+  /**
+   * note: Pelias has four different query modes:
+   * /v1/autocomplete: for partially completed inputs (such as when a user types)
+   * /v1/search: for completed inputs (such as when geocoding a CSV file)
+   * /v1/search/structured: for completed inputs with fields already separated
+   * /v1/reverse: for finding places nearby/enveloping a point
+   */
+  endpoint({ query, type }: EndpointArgument) {
+    switch (type) {
+      // case RequestType.AUTOCOMPLETE:
+      //   const autocompleteParams = (typeof query === 'string') ? { text: query } : query;
+      //   return this.getUrl(`${this.host}/v1/autocomplete`, autocompleteParams);
+
+      // case RequestType.FULLTEXT:
+      //   const searchParams = (typeof query === 'string') ? { text: query } : query;
+      //   return this.getUrl(`${this.host}/v1/search`, searchParams);
+
+      // case RequestType.STRUCTURED:
+      //   const structuredParams = (typeof query === 'string') ? { address: query } : query;
+      //   return this.getUrl(`${this.host}/v1/search/structured`, structuredParams);
+
+      case RequestType.REVERSE:
+        const reverseParams = typeof query === 'string' ? {} : query;
+        return this.getUrl(`${this.host}/v1/reverse`, reverseParams);
+
+      // note: the default query mode is set to 'autocomplete'
+      default:
+        const autocompleteParams =
+          typeof query === 'string' ? { text: query } : query;
+        return this.getUrl(`${this.host}/v1/autocomplete`, autocompleteParams);
+    }
+  }
+
+  parse(response: ParseArgument<RequestResult>): SearchResult<RawResult>[] {
+    return response.data.features.map((feature) => {
+      const res: SearchResult<RawResult> = {
+        x: feature.geometry.coordinates[0],
+        y: feature.geometry.coordinates[1],
+        label: feature.properties.label,
+        bounds: null,
+        raw: feature,
+      };
+
+      // bbox values are only available for features derived from non-point geometries
+      // geojson bbox format: [minX, minY, maxX, maxY]
+      if (Array.isArray(feature.bbox) && feature.bbox.length === 4) {
+        res.bounds = [
+          [feature.bbox[1], feature.bbox[0]], // s, w
+          [feature.bbox[3], feature.bbox[2]], // n, e
+        ];
+      }
+
+      return res;
+    });
+  }
+}


### PR DESCRIPTION
This PR adds a new provider for [Pelias](https://github.com/pelias/pelias).

Since Pelias is self-hosted and FOSS I've ~~had to change the constructor a little~~ added a 'host' option to allow the user to configure the location of a running Pelias server.
The default value for this is `http://localhost:4000` which matches the default port bound by [Docker](https://github.com/pelias/docker) projects.

As such you'll need a locally running instance to test, I'll follow up with a small PR which adds the [GeocodeEarth](https://geocode.earth/) provider, this is a hosted version of Pelias run by the core team which provides the same API but with an additional `api_key` param.

I'm new to TypeScript so please let me know what I broke :P

<img width="1151" alt="Screenshot 2021-10-08 at 16 51 51" src="https://user-images.githubusercontent.com/738069/136579063-cd64b9d0-fba4-4295-9244-7b6ab26a054f.png">


