### PR TITLE
provider: Geocode Earth

### DIFF
--- a/docs/lib/providers.ts
+++ b/docs/lib/providers.ts
@@ -2,6 +2,7 @@ import {
   AlgoliaProvider,
   BingProvider,
   EsriProvider,
+  GeocodeEarthProvider,
   GoogleProvider,
   HereProvider,
   LocationIQProvider,
@@ -19,6 +20,11 @@ export default {
   }),
 
   Esri: new EsriProvider(),
+
+  GeocodeEarth: new GeocodeEarthProvider({
+    // eslint-disable-next-line @typescript-eslint/camelcase
+    params: { api_key: process.env.GATSBY_GEOCODEEARTH_API_KEY },
+  }),
 
   Google: new GoogleProvider({
     params: { key: process.env.GATSBY_GOOGLE_API_KEY },

--- a/docs/providers/geocode-earth.mdx
+++ b/docs/providers/geocode-earth.mdx
@@ -1,0 +1,71 @@
+---
+name: Geocode Earth
+menu: Providers
+route: /providers/geocode-earth
+---
+
+import Playground from '../components/Playground';
+import Map from '../components/Map';
+
+# Geocode Earth Provider
+
+Geocode Earth is a hosted version of Pelias run by the core maintainers of the FOSS project.
+
+**note**: Geocode Earth services require an API key, grab a [free trial key][1] from their website.
+
+For more options and configurations, see the [documentation][2].
+
+<Playground>
+  <Map provider="GeocodeEarth" />
+</Playground>
+
+```js
+import { GeocodeEarthProvider } from 'leaflet-geosearch';
+
+// grab an API key from https://geocode.earth
+const provider = new GeocodeEarthProvider({
+  params: {
+    api_key: '__YOUR_GEOCODE_EARTH_KEY__',
+  },
+});
+
+// add to leaflet
+import { GeoSearchControl } from 'leaflet-geosearch';
+
+map.addControl(
+  new GeoSearchControl({
+    provider,
+  }),
+);
+```
+
+
+## Optional parameters
+
+Geocode Earth supports a wide range of number of [optional parameters][2] which can be applied to every request using the `params` object:
+
+```js
+const provider = new GeocodeEarthProvider({
+  params: {
+    size: 5, // limit the total number of results returned
+    lang: 'nl', // render results in Dutch
+    'boundary.country': 'NL', // limit search results to the Netherlands
+    layers: 'address,street', // limmit which layers are queried
+  },
+});
+```
+
+Or individually on a per-request basis:
+
+```js
+const results = await provider.search({
+  query: {
+    text: 'example',
+    'focus.point.lat': 1.11, // score results nearer to the focus point higher
+    'focus.point.lon': 2.22,
+  },
+});
+```
+
+[1]: https://geocode.earth/
+[2]: https://geocode.earth/docs/

--- a/docs/providers/pelias.mdx
+++ b/docs/providers/pelias.mdx
@@ -17,6 +17,8 @@ The [Docker][3] repository provides the quickest path to running your own server
 
 See the [Pelias documentation][2] for more detailed information about the available endpoints and query parameters.
 
+Looking for a hosted version of Pelias? check out the Geocode Earth provider.
+
 <Playground>
   <Map provider="Pelias" />
 </Playground>

--- a/doczrc.js
+++ b/doczrc.js
@@ -20,6 +20,7 @@ export default {
         'Algolia',
         'Bing',
         'Esri',
+        'Geocode Earth',
         'Google',
         'Here',
         'LocationIQ',

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export { default as SearchElement } from './SearchElement';
 export { default as AlgoliaProvider } from './providers/algoliaProvider';
 export { default as BingProvider } from './providers/bingProvider';
 export { default as EsriProvider } from './providers/esriProvider';
+export { default as GeocodeEarthProvider } from './providers/geocodeEarthProvider';
 export { default as GoogleProvider } from './providers/googleProvider';
 export { default as HereProvider } from './providers/hereProvider';
 export { default as LocationIQProvider } from './providers/locationIQProvider';

--- a/src/providers/__tests__/geocodeEarthProvider.spec.js
+++ b/src/providers/__tests__/geocodeEarthProvider.spec.js
@@ -1,0 +1,30 @@
+import Provider from '../geocodeEarthProvider';
+import fixture from './peliasResponse.json';
+
+describe('GeocodeEarthProvider', function () {
+  beforeAll(() => {
+    fetch.mockResponse(async () => ({ body: JSON.stringify(fixture) }));
+  });
+
+  test('Can fetch results', async () => {
+    const provider = new Provider();
+    const results = await provider.search({ query: 'pelias' });
+    expect(results.length).toEqual(9);
+
+    // feature mapping
+    results.forEach((result, i) => {
+      const feat = fixture.features[i];
+      expect(result.label).toBeTruthy();
+      expect(result.x).toEqual(+feat.geometry.coordinates[0]);
+      expect(result.y).toEqual(+feat.geometry.coordinates[1]);
+
+      // bounding box range checks
+      if (feat.bbox) {
+        expect(result.bounds[0][0]).toBeLessThan(result.bounds[1][0]); // south less than north
+        expect(result.bounds[0][1]).toBeLessThan(result.bounds[1][1]); // west less than east
+      } else {
+        expect(result.bounds).toBeFalsy();
+      }
+    });
+  });
+});

--- a/src/providers/geocodeEarthProvider.ts
+++ b/src/providers/geocodeEarthProvider.ts
@@ -1,0 +1,8 @@
+import PeliasProvider, { PeliasProviderOptions } from './peliasProvider';
+
+export default class GeocodeEarthProvider extends PeliasProvider {
+  constructor(options: PeliasProviderOptions = {}) {
+    options.host = 'https://api.geocode.earth';
+    super(options);
+  }
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,6 +1,7 @@
 export { default as AlgoliaProvider } from './algoliaProvider';
 export { default as BingProvider } from './bingProvider';
 export { default as EsriProvider } from './esriProvider';
+export { default as GeocodeEarthProvider } from './geocodeEarthProvider';
 export { default as GoogleProvider } from './googleProvider';
 export { default as LocationIQProvider } from './locationIQProvider';
 export { default as OpenCageProvider } from './openCageProvider';


### PR DESCRIPTION
as mentioned in https://github.com/smeijer/leaflet-geosearch/pull/295, this PR adds the provider Geocode Earth which is an extension of the Pelias provider from that PR.

this PR is based on https://github.com/smeijer/leaflet-geosearch/pull/295, so it's probably easiest to merge that first or just check out the second commit to see the diff.