### PR TITLE
chore: add trailing semicolon

### DIFF
--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -1,4 +1,4 @@
-import * as L from 'leaflet'
+import * as L from 'leaflet';
 import { ControlPosition, FeatureGroup, MarkerOptions, Map } from 'leaflet';
 import SearchElement from './SearchElement';
 import ResultList from './resultList';


### PR DESCRIPTION
This minor PR adds a missing trailing semicolon which was causing the CI environment to fail:

 ```bash
 /home/runner/work/leaflet-geosearch/leaflet-geosearch/src/SearchControl.ts
Error:     1:29  error    Insert `;`                                    prettier/prettier
```

 https://github.com/smeijer/leaflet-geosearch/pull/295/checks?check_run_id=3858577892
 
 The changes were generated automatically with the following command (note the `--fix`):

```bash
 npm run ci:lint -- $(git diff --diff-filter d --name-only origin/develop...HEAD -- '*.js' '*.ts' '*.tsx') --fix
 ```