### PR TITLE
docs: make code examples consistent with map examples

### DIFF
--- a/docs/leaflet-control.mdx
+++ b/docs/leaflet-control.mdx
@@ -22,6 +22,7 @@ import { SearchControl, OpenStreetMapProvider } from 'leaflet-geosearch';
 
 const searchControl = new SearchControl({
   provider: new OpenStreetMapProvider(),
+  style: 'bar',
 });
 
 map.addControl(searchControl);
@@ -61,6 +62,7 @@ import { SearchControl, OpenStreetMapProvider } from 'leaflet-geosearch';
 const searchControl = new SearchControl({
   notFoundMessage: 'Sorry, that address could not be found.',
   provider: new OpenStreetMapProvider(),
+  style: 'bar',
 });
 
 map.addControl(searchControl);

--- a/docs/providers/algolia.mdx
+++ b/docs/providers/algolia.mdx
@@ -26,6 +26,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/bing.mdx
+++ b/docs/providers/bing.mdx
@@ -31,6 +31,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/esri.mdx
+++ b/docs/providers/esri.mdx
@@ -26,6 +26,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/geoapifr.mdx
+++ b/docs/providers/geoapifr.mdx
@@ -26,6 +26,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/geocode-earth.mdx
+++ b/docs/providers/geocode-earth.mdx
@@ -35,6 +35,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/google.mdx
+++ b/docs/providers/google.mdx
@@ -31,6 +31,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/here.mdx
+++ b/docs/providers/here.mdx
@@ -31,6 +31,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/locationIq.mdx
+++ b/docs/providers/locationIq.mdx
@@ -31,6 +31,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/opencage.mdx
+++ b/docs/providers/opencage.mdx
@@ -31,6 +31,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/openstreetmap.mdx
+++ b/docs/providers/openstreetmap.mdx
@@ -26,6 +26,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/providers/pelias.mdx
+++ b/docs/providers/pelias.mdx
@@ -37,6 +37,7 @@ import { GeoSearchControl } from 'leaflet-geosearch';
 map.addControl(
   new GeoSearchControl({
     provider,
+    style: 'bar',
   }),
 );
 ```

--- a/docs/usage.mdx
+++ b/docs/usage.mdx
@@ -41,6 +41,7 @@ import { GeoSearchControl, OpenStreetMapProvider } from 'leaflet-geosearch';
 
 const searchControl = new GeoSearchControl({
   provider: new OpenStreetMapProvider(),
+  style: 'bar',
 });
 
 map.addControl(searchControl);


### PR DESCRIPTION
By default, many of the Playground maps use the 'bar' style
search control, but the code examples associated with the maps
do not specify the style. This ends up rendering a map with a
button-style control, which does not match the example maps.

This commit updates the documentation to specify `style: 'bar'`
whenever the associated example map is using a bar.