### PR TITLE
fix: set height of search box to match surrounding boxes

### DIFF
--- a/assets/css/leaflet.css
+++ b/assets/css/leaflet.css
@@ -109,7 +109,7 @@
   margin: 0;
   padding: 0;
   font-size: 12px;
-  height: 26px;
+  height: 30px;
   border: none;
   border-radius: 0 4px 4px 0;
   text-indent: 8px;


### PR DESCRIPTION
Before:
<img width="278" alt="image" src="https://user-images.githubusercontent.com/86784/164042058-54e867b6-ff7a-44ee-a9f9-4daf221583db.png">

After:
<img width="289" alt="image" src="https://user-images.githubusercontent.com/86784/164042080-d8f250d1-9644-44e4-aece-67f36dd864c3.png">
