### PR TITLE
fix: add support for leaflet 1.8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [setup]
     timeout-minutes: 5
+    strategy:
+      matrix:
+        leaflet: ["1.6.0", "1.7.1", "1.8.0"]
     steps:
       - uses: actions/checkout@v2
 
@@ -95,6 +98,9 @@ jobs:
         with:
           path: node_modules
           key: ${{ runner.os }}-node_modules-${{ hashFiles('**/package-lock.json') }}
+
+      - name: install specific leaflet version
+        run: npm install leaflet@${{ matrix.leaflet }}
 
       - name: unit tests
         run: npm run ci:test

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -164,7 +164,7 @@ const Control: SearchControl = {
     }
 
     // merge given options with control defaults
-    this.options = { ...this.options, ...options };
+    this.options = { ...defaultOptions, ...options };
     this.classNames = { ...this.classNames, ...options.classNames };
 
     this.markers = new L.FeatureGroup();

--- a/src/__tests__/SearchControl.spec.js
+++ b/src/__tests__/SearchControl.spec.js
@@ -84,3 +84,9 @@ test('Change view on result', () => {
 
   expect(map.setView).toHaveBeenCalled();
 });
+
+test('Default options are applied', () => {
+  const control = new SearchControl({ provider: jest.fn() });
+
+  expect(control.options).toEqual(expect.objectContaining({ style: 'button' }));
+});


### PR DESCRIPTION
hi,

this should fix failures in combination with leaflet-1.8.0.

It is required as a workaround since https://github.com/Leaflet/Leaflet/pull/7459 landed in leaflet.

I am not very familiar with the github workflow system, thus the ci commit might not be the correct solution,
consider it as a rfc. There might be a better solution I am not aware of.

BR,
Valentin Kunz