### PR TITLE
Align OpenStreetMapProvider's RawResult with Nominatim API

### DIFF
--- a/src/providers/openStreetMapProvider.ts
+++ b/src/providers/openStreetMapProvider.ts
@@ -12,7 +12,7 @@ export type RequestResult = RawResult[];
 
 export interface RawResult {
   place_id: string;
-  license: string;
+  licence: string;
   osm_type: string;
   osm_id: number;
   boundingbox: [string, string, string, string];


### PR DESCRIPTION
See https://nominatim.org/release-docs/develop/api/Search/. The API uses the less common form "licence".

When using `leaflet-geosearch` with TypeScript, accessing `result.raw.licence` causes a compilation error and needs to be worked around by using `// @ts-ignore`.

Using `result.raw.license` obviously contains no data.

<details>
<summary>
Click to expand a response example:
</summary>

```json
    {
        "address": {
            "bakery": "B\u00e4cker Kamps",
            "city_district": "Mitte",
            "continent": "European Union",
            "country": "Deutschland",
            "country_code": "de",
            "footway": "Bahnsteig U6",
            "neighbourhood": "Sprengelkiez",
            "postcode": "13353",
            "state": "Berlin",
            "suburb": "Wedding"
        },
        "boundingbox": [
            "52.5460929870605",
            "52.5460968017578",
            "13.3591794967651",
            "13.3591804504395"
        ],
        "class": "shop",
        "display_name": "B\u00e4cker Kamps, Bahnsteig U6, Sprengelkiez, Wedding, Mitte, Berlin, 13353, Deutschland, European Union",
        "icon": "https://nominatim.openstreetmap.org/images/mapicons/shopping_bakery.p.20.png",
        "importance": 0.201,
        "lat": "52.5460941",
        "licence": "Data \u00a9 OpenStreetMap contributors, ODbL 1.0. https://www.openstreetmap.org/copyright",
        "lon": "13.35918",
        "osm_id": "317179427",
        "osm_type": "node",
        "place_id": "1453068",
        "type": "bakery"
    }
```
</details>