### PR TITLE
fix: OpenStreetMap named their prop licence, not license.

### DIFF
--- a/src/providers/openStreetMapProvider.ts
+++ b/src/providers/openStreetMapProvider.ts
@@ -11,7 +11,7 @@ export type RequestResult = RawResult[];
 
 export interface RawResult {
   place_id: string;
-  license: string;
+  licence: string;
   osm_type: string;
   osm_id: number;
   boundingbox: [string, string, string, string];


### PR DESCRIPTION
See #355. That pull got merged in the wrong branch. 