### PR TITLE
Add handling of lat, lon coordinate queries

### DIFF
--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -374,7 +374,7 @@ const Control: SearchControl = {
     const { provider } = this.options;
 
     if (query.length) {
-      var results = [];
+      const results = [];
       const coords = validateCoords(query);
       if (coords) {
         results = coords;

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -395,7 +395,7 @@ const Control: SearchControl = {
     var results = [];
     const coords = validateCoords(query);
     if (coords) {
-        results = coords;
+      results = coords;
     } else {
         results = await provider!.search(query);
     }

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -379,7 +379,7 @@ const Control: SearchControl = {
       if (coords) {
         results = coords;
       } else {
-        results = await provider!.search({query});
+        results = await provider!.search({ query });
       }
       results = results.slice(0, this.options.maxSuggestions);
       this.resultList.render(results, this.options.resultFormat);

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -3,6 +3,7 @@ import { ControlPosition, FeatureGroup, MarkerOptions, Map } from 'leaflet';
 import SearchElement from './SearchElement';
 import ResultList from './resultList';
 import debounce from './lib/debounce';
+import { validateCoords } from './coords';
 
 import {
   createElement,
@@ -373,7 +374,13 @@ const Control: SearchControl = {
     const { provider } = this.options;
 
     if (query.length) {
-      let results = await provider!.search({ query });
+      var results = [];
+      const coords = validateCoords({query});
+      if (coords) {
+        results = coords;
+      } else {
+        results = await provider!.search({query});
+      }
       results = results.slice(0, this.options.maxSuggestions);
       this.resultList.render(results, this.options.resultFormat);
     } else {
@@ -384,7 +391,13 @@ const Control: SearchControl = {
   async onSubmit(query) {
     const { provider } = this.options;
 
-    const results = await provider!.search(query);
+    var results = [];
+    const coords = validateCoords(query);
+    if (coords) {
+        results = coords;
+    } else {
+        results = await provider!.search(query);
+    }
 
     if (results && results.length > 0) {
       this.showResult(results[0], query);

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -397,7 +397,7 @@ const Control: SearchControl = {
     if (coords) {
       results = coords;
     } else {
-        results = await provider!.search(query);
+      results = await provider!.search(query);
     }
 
     if (results && results.length > 0) {

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -375,7 +375,7 @@ const Control: SearchControl = {
 
     if (query.length) {
       var results = [];
-      const coords = validateCoords({query});
+      const coords = validateCoords(query);
       if (coords) {
         results = coords;
       } else {

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -374,7 +374,7 @@ const Control: SearchControl = {
     const { provider } = this.options;
 
     if (query.length) {
-      const results = [];
+      let results = [];
       const coords = validateCoords(query);
       if (coords) {
         results = coords;
@@ -392,7 +392,7 @@ const Control: SearchControl = {
     this.resultList.clear();
     const { provider } = this.options;
 
-    const results = [];
+    let results = [];
     const coords = validateCoords(query);
     if (coords) {
       results = coords;

--- a/src/SearchControl.ts
+++ b/src/SearchControl.ts
@@ -392,7 +392,7 @@ const Control: SearchControl = {
     this.resultList.clear();
     const { provider } = this.options;
 
-    var results = [];
+    const results = [];
     const coords = validateCoords(query);
     if (coords) {
       results = coords;

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 
 export function validateCoords(query) {
-    const q = query.trim();
+  const q = query.trim();
     const regex = /^(-?[0-9]*\.?\s*[0-9]*)\s*,?\s*(-?[0-9]*\.?[0-9]*)$/g;
     const match = regex.exec(q);
     if (match) {

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -14,9 +14,9 @@ export function validateCoords(query) {
           y: lat,
           label: q,
           bounds: null,
-          raw: {}
-      },
-    ];
+          raw: {},
+        },
+      ];
     }
   }
   return false;

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -2,11 +2,11 @@
 
 export function validateCoords(query) {
   const q = query.trim();
-    const regex = /^(-?[0-9]*\.?\s*[0-9]*)\s*,?\s*(-?[0-9]*\.?[0-9]*)$/g;
-    const match = regex.exec(q);
-    if (match) {
-        var lat = Number(match[1]);
-        var lng = Number(match[2]);
+  const regex = /^(-?[0-9]*\.?\s*[0-9]*)\s*,?\s*(-?[0-9]*\.?[0-9]*)$/g;
+  const match = regex.exec(q);
+  if (match) {
+    let lat = Number(match[1]);
+    let lng = Number(match[2]);
         if (( -90 < lat < 90) && ( -180 < lng < 180)) {
             return [{
                 x: lng,

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -5,9 +5,9 @@ export function validateCoords(query) {
   const regex = /^(-?[0-9]*\.?\s*[0-9]*)\s*,?\s*(-?[0-9]*\.?[0-9]*)$/g;
   const match = regex.exec(q);
   if (match) {
-    let lat = Number(match[1]);
-    let lng = Number(match[2]);
-        if (( -90 < lat < 90) && ( -180 < lng < 180)) {
+    const lat = Number(match[1]);
+    const lng = Number(match[2]);
+    if (-90 < lat < 90 && -180 < lng < 180) {
             return [{
                 x: lng,
                 y: lat,

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -3,7 +3,7 @@
 export function validateCoords(query) {
     const q = query.trim();
     const regex = /^(-?[0-9]*\.?\s*[0-9]*)\s*,?\s*(-?[0-9]*\.?[0-9]*)$/g;
-    var match = regex.exec(q);
+    const match = regex.exec(q);
     if (match) {
         var lat = Number(match[1]);
         var lng = Number(match[2]);

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -1,7 +1,7 @@
 // @ts-nocheck
 
 export function validateCoords(query) {
-    const q = query.query.trim();
+    const q = query.trim();
     const regex = /^(-?[0-9]*\.?\s*[0-9]*)\s*,?\s*(-?[0-9]*\.?[0-9]*)$/g;
     var match = regex.exec(q);
     if (match) {

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -1,0 +1,21 @@
+// @ts-nocheck
+
+export function validateCoords(query) {
+    const q = query.query.trim();
+    const regex = /^(-?[0-9]*\.?\s*[0-9]*)\s*,?\s*(-?[0-9]*\.?[0-9]*)$/g;
+    var match = regex.exec(q);
+    if (match) {
+        var lat = Number(match[1]);
+        var lng = Number(match[2]);
+        if (( -90 < lat < 90) && ( -180 < lng < 180)) {
+            return [{
+                x: lng,
+                y: lat,
+                label: q,
+                bounds: null,
+                raw: {}
+            }];
+        }
+    }
+    return false;
+}

--- a/src/coords.ts
+++ b/src/coords.ts
@@ -8,14 +8,16 @@ export function validateCoords(query) {
     const lat = Number(match[1]);
     const lng = Number(match[2]);
     if (-90 < lat < 90 && -180 < lng < 180) {
-            return [{
-                x: lng,
-                y: lat,
-                label: q,
-                bounds: null,
-                raw: {}
-            }];
-        }
+      return [
+        {
+          x: lng,
+          y: lat,
+          label: q,
+          bounds: null,
+          raw: {}
+      },
+    ];
     }
-    return false;
+  }
+  return false;
 }


### PR DESCRIPTION
Quick, *pure js* implementation to handle coordinate queries (#147). If a user enters valid coordinates, they get a single result with that point (as in Google Maps and other services). It's a useful feature for power users.
![image](https://github.com/smeijer/leaflet-geosearch/assets/8945883/775ac7a2-3802-44e8-a3d5-c59d91d579e6)

Any other queries are sent to the Provider. Happy to see this in TypeScript and otherwise improved, it's probably not ready for merging.