### PR TITLE
fix: button styling improvements

### DIFF
--- a/assets/css/leaflet.css
+++ b/assets/css/leaflet.css
@@ -74,7 +74,7 @@
   display: none;
   position: absolute;
   top: 0;
-  left: 36px;
+  left: 30px;
   border-radius: 0 4px 4px 0;
   background-color: #fff;
   background-clip: padding-box;
@@ -94,7 +94,7 @@
 
 .leaflet-geosearch-button.active .leaflet-bar-part {
   border-radius: 4px 0 0 4px;
-  width: 36px;
+  width: 30px;
 }
 
 .leaflet-geosearch-button form {

--- a/assets/css/leaflet.css
+++ b/assets/css/leaflet.css
@@ -20,16 +20,16 @@
 
 /* magnifying glass */
 .leaflet-control-geosearch a.leaflet-bar-part:before {
-  top: 15px;
-  left: 13px;
+  top: 17px;
+  left: 15px;
   width: 6px;
   border-top: 2px solid #555;
   transform: rotateZ(45deg);
 }
 
 .leaflet-control-geosearch a.leaflet-bar-part:after {
-  top: 8px;
-  left: 8px;
+  top: 10px;
+  left: 10px;
   height: 8px;
   width: 8px;
   border-radius: 50%;


### PR DESCRIPTION
Minor changes to centre the magnifying glass icon and stop it moving around when clicking the button.

I've tested this on a few different browsers across several OSs (Win10, MacOS, IOS, Android), hopefully that's sufficient.