### PR TITLE
fix error when importing leaflet-geosearch using TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
       "browser": "./dist/geosearch.module.js",
       "umd": "./dist/geosearch.umd.js",
       "import": "./dist/geosearch.module.js",
-      "require": "./dist/geosearch.js"
+      "require": "./dist/geosearch.js",
+      "types": "./dist/index.d.ts"
     },
     "./package.json": "./package.json",
     "./*": "./*"


### PR DESCRIPTION
fix #370

If it's not too much trouble, could you please add the `hacktoberfest-accepted` tag to this PR?