### PR TITLE
fix: ensure remote errors in LocationIQ Provider are handled

### DIFF
--- a/src/providers/locationIQProvider.ts
+++ b/src/providers/locationIQProvider.ts
@@ -7,10 +7,7 @@ import OpenStreetMapProvider, {
 interface RequestResultWithError extends RequestResult {
   error?: string;
 }
-import {
-  ParseArgument,
-  SearchResult,
-} from './provider';
+import { ParseArgument, SearchResult } from './provider';
 
 export default class LocationIQProvider extends OpenStreetMapProvider {
   constructor(options: OpenStreetMapProviderOptions) {
@@ -21,7 +18,9 @@ export default class LocationIQProvider extends OpenStreetMapProvider {
     });
   }
 
-  parse(response: ParseArgument<RequestResultWithError>): SearchResult<RawResult>[] {
+  parse(
+    response: ParseArgument<RequestResultWithError>,
+  ): SearchResult<RawResult>[] {
     if (response.data.error) {
       return [];
     }

--- a/src/providers/locationIQProvider.ts
+++ b/src/providers/locationIQProvider.ts
@@ -4,6 +4,9 @@ import OpenStreetMapProvider, {
   RequestResult,
 } from './openStreetMapProvider';
 
+interface RequestResultWithError extends RequestResult {
+  error?: string;
+}
 import {
   ParseArgument,
   SearchResult,
@@ -18,7 +21,7 @@ export default class LocationIQProvider extends OpenStreetMapProvider {
     });
   }
 
-  parse(response: ParseArgument<RequestResult>): SearchResult<RawResult>[] {
+  parse(response: ParseArgument<RequestResultWithError>): SearchResult<RawResult>[] {
     if (response.data.error) {
       return [];
     }

--- a/src/providers/locationIQProvider.ts
+++ b/src/providers/locationIQProvider.ts
@@ -1,6 +1,13 @@
 import OpenStreetMapProvider, {
   OpenStreetMapProviderOptions,
+  RawResult,
+  RequestResult,
 } from './openStreetMapProvider';
+
+import {
+  ParseArgument,
+  SearchResult,
+} from './provider';
 
 export default class LocationIQProvider extends OpenStreetMapProvider {
   constructor(options: OpenStreetMapProviderOptions) {
@@ -9,5 +16,12 @@ export default class LocationIQProvider extends OpenStreetMapProvider {
       searchUrl: `https://locationiq.org/v1/search.php`,
       reverseUrl: `https://locationiq.org/v1/reverse.php`,
     });
+  }
+
+  parse(response: ParseArgument<RequestResult>): SearchResult<RawResult>[] {
+    if (response.data.error) {
+      return [];
+    }
+    return super.parse(response);
   }
 }


### PR DESCRIPTION
Location IQ throws a 404 error when it is unable to locate any match.  such as when typing "san Angl" and there are no places that begin with that string.  To repair, the parse method checks for the `response.data.error` in the response, returns an empty string if it has an error, and otherwise, hands back up to the parent class.  

I am new to this library (and not a typescript expert), so while I believe this works, if there is a better way to handle errors, happy to learn!