### PR TITLE
Export google provider types

### DIFF
--- a/src/providers/googleProvider.ts
+++ b/src/providers/googleProvider.ts
@@ -7,12 +7,12 @@ import AbstractProvider, {
 } from './provider';
 import { Loader, LoaderOptions } from '@googlemaps/js-api-loader';
 
-interface RequestResult {
+export interface RequestResult {
   results: google.maps.GeocoderResult[];
   status?: google.maps.GeocoderStatus;
 }
 
-interface GeocodeError {
+export interface GeocodeError {
   code: Exclude<google.maps.GeocoderStatus, google.maps.GeocoderStatus.OK>;
   endpoint: 'GEOCODER_GEOCODE';
   message: string;


### PR DESCRIPTION
Exported the missing types that are commonly used when using the google provider.