### PR TITLE
Added AMap(Gaode) provider

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,5 +16,6 @@ export { default as PeliasProvider } from './providers/peliasProvider';
 export { default as MapBoxProvider } from './providers/mapBoxProvider';
 export { default as GeoApiFrProvider } from './providers/geoApiFrProvider';
 export { default as GeoapifyProvider } from './providers/geoapifyProvider';
+export { default as AMapProvider } from './providers/amapProvider';
 
 export { default as JsonProvider } from './providers/provider';

--- a/src/providers/amapProvider.ts
+++ b/src/providers/amapProvider.ts
@@ -1,0 +1,51 @@
+import AbstractProvider, {
+  EndpointArgument,
+  ParseArgument,
+  SearchResult,
+} from './provider';
+
+export type RequestResult = {
+  status: number;
+  count: number;
+  info: string;
+  geocodes: RawResult[];
+};
+
+export interface RawResult {
+  formatted_address: string;
+  country: string;
+  province: string;
+  city: string;
+  citycode: string;
+  district: string;
+  number: string;
+  adcode: string;
+  location: string;
+  level: string;
+}
+
+export default class AMapProvider extends AbstractProvider<
+  RequestResult,
+  RawResult
+> {
+  searchUrl = 'https://restapi.amap.com/v3/geocode/geo';
+
+  endpoint({ query }: EndpointArgument): string {
+    const params = typeof query === 'string' ? { address: query } : query;
+    params.output = 'JSON';
+
+    return this.getUrl(this.searchUrl, params);
+  }
+
+  parse(response: ParseArgument<RequestResult>): SearchResult<RawResult>[] {
+    const records = response.data.geocodes;
+
+    return records.map((r) => ({
+      x: Number(r.location.substring(0, r.location.indexOf(','))),
+      y: Number(r.location.substring(r.location.indexOf(',') + 1)),
+      label: r.formatted_address,
+      bounds: null,
+      raw: r,
+    }));
+  }
+}


### PR DESCRIPTION
Added AMap(Gaode as Chinese name) provider for geo search. An API key is needed to use this provider. See [AMap GEO API Doc](https://lbs.amap.com/api/webservice/guide/api/georegeo) for details.

Usage:

```javascript
import { AMapProvider } from 'leaflet-geosearch'

const provider = new AMapProvider({
      params: {
        key: process.env.AMAP_API_KEY, // Put your api key here
      },
    });

const results = await provider.search({ query: '上海市浦东新区外滩' });
```