### PR TITLE
Update README.md to include missing CSS import.

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,8 @@ leaflet example.
 ```jsx
 import { GeoSearchControl, MapBoxProvider } from 'leaflet-geosearch';
 import { useMap } from 'react-leaflet';
+import "leaflet-geosearch/assets/css/leaflet.css";
+
 const SearchField = ({ apiKey }) => {
   const provider = new MapBoxProvider({
     params: {


### PR DESCRIPTION
Followed the provided example to use with react-leaflet and noticed a css import was missing.