### PR TITLE
fix: change URL of Here API

### DIFF
--- a/src/providers/hereProvider.ts
+++ b/src/providers/hereProvider.ts
@@ -41,7 +41,7 @@ export default class HereProvider extends AbstractProvider<
   RequestResult,
   RawResult
 > {
-  searchUrl = 'https://geocode.search.hereapi.com/v1/autosuggest';
+  searchUrl = 'https://geocode.search.hereapi.com/v1/geocode';
 
   endpoint({ query }: EndpointArgument): string {
     const params = typeof query === 'string' ? { q: query } : query;


### PR DESCRIPTION
The Here service API URL is wrong. It only needs one word change to make it work properly.