### PR TITLE
fix: Geoapify results without bounding box fixed #427 closes

### DIFF
--- a/src/providers/__tests__/geoapifyProvider.spec.js
+++ b/src/providers/__tests__/geoapifyProvider.spec.js
@@ -22,6 +22,32 @@ describe('Geoapify', () => {
     expect(result.bounds).toBeValidBounds();
   });
 
+  test('Can handle results without bbox', () => {
+    const provider = new Provider();
+    // Mock response with results that don't have bbox
+    const mockResponse = {
+      results: [
+        {
+          country: 'United States',
+          country_code: 'us',
+          state: 'Illinois',
+          lon: '-87.625848',
+          lat: '41.706446',
+          formatted:
+            '60 West 103rd Place, Chicago, IL 60628, United States of America',
+        },
+      ],
+    };
+
+    const results = provider.parse({ data: mockResponse });
+    const result = results[0];
+
+    expect(result.label).toBeTruthy();
+    expect(result.x).toEqual(-87.625848);
+    expect(result.y).toEqual(41.706446);
+    expect(result.bounds).toBeNull(); // Should be null when no bbox
+  });
+
   test.skip('Can get localized results', async () => {
     const provider = new Provider({
       params: {

--- a/src/providers/geoapifyProvider.ts
+++ b/src/providers/geoapifyProvider.ts
@@ -1,4 +1,5 @@
 import AbstractProvider, {
+  BoundsTuple,
   EndpointArgument,
   ParseArgument,
   ProviderOptions,
@@ -24,7 +25,7 @@ export interface RawResult {
   lat: string;
   state_code: string;
   formatted: string;
-  bbox: BBox;
+  bbox?: BBox;
 }
 
 export interface RawQuery {
@@ -81,15 +82,21 @@ export default class GeoapifyProvider extends AbstractProvider<
     const records = Array.isArray(response.data.results)
       ? response.data.results
       : [response.data.results];
-    return records.map((r) => ({
-      x: Number(r.lon),
-      y: Number(r.lat),
-      label: r.formatted,
-      bounds: [
-        [parseFloat(r.bbox.lat1), parseFloat(r.bbox.lon1)], // s, w
-        [parseFloat(r.bbox.lat2), parseFloat(r.bbox.lon2)], // n, e
-      ],
-      raw: r,
-    }));
+    return records.map((r) => {
+      let bounds = null;
+      if (r.bbox) {
+        bounds = [
+          [parseFloat(r.bbox.lat1), parseFloat(r.bbox.lon1)], // s, w
+          [parseFloat(r.bbox.lat2), parseFloat(r.bbox.lon2)], // n, e
+        ] as BoundsTuple;
+      }
+      return {
+        x: Number(r.lon),
+        y: Number(r.lat),
+        label: r.formatted,
+        bounds,
+        raw: r,
+      };
+    });
   }
 }


### PR DESCRIPTION
This change prevents the plugin to thow an error when the `bounds` attribute is absent from the API result

✅ Closes: #427