### PR TITLE
feat: add name to search input

### DIFF
--- a/src/SearchElement.ts
+++ b/src/SearchElement.ts
@@ -56,6 +56,7 @@ export default class SearchElement {
       {
         type: 'text',
         placeholder: searchLabel || 'search',
+        name: 'geosearch',
         onInput: this.onInput,
         onKeyUp: (e) => this.onKeyUp(e),
         onKeyPress: (e) => this.onKeyPress(e),


### PR DESCRIPTION
This helps browsers and password managers to understand the field and will hide autofill-actions.

Example of 1Password context button here (without fix):
<img width="1217" height="470" alt="afbeelding" src="https://github.com/user-attachments/assets/8209332b-a830-43f1-81cf-5e0bb0a2d8ae" />
