### PR TITLE
fix: geoApiFrProvider underlying API has moved

### DIFF
--- a/docs/providers/geoapifr.mdx
+++ b/docs/providers/geoapifr.mdx
@@ -39,8 +39,8 @@ All options defined next to the `params` key, would have been added to the reque
 
 ```js
 const provider = new GeoApiFrProvider({
-  searchUrl: 'https://api-adresse.data.gouv.fr/search',
-  reverseUrl: 'https://api-adresse.data.gouv.fr/reverse',
+  searchUrl: 'https://data.geopf.fr/geocodage/search',
+  reverseUrl: 'https://data.geopf.fr/geocodage/reverse',
   params: {
     type: 'municipality', // limit search results to city
     autocomplete: 1, // Use in autocomplete mode (search in prefix mode)
@@ -50,5 +50,5 @@ const provider = new GeoApiFrProvider({
 });
 ```
 
-[1]: https://geo.api.gouv.fr/
-[2]: https://geo.api.gouv.fr/adresse
+[1]: https://geoservices.ign.fr/documentation/services/services-geoplateforme/geocodage
+[2]: https://data.geopf.fr/geocodage/openapi

--- a/src/providers/geoApiFrProvider.ts
+++ b/src/providers/geoApiFrProvider.ts
@@ -55,9 +55,9 @@ export default class GeoApiFrProvider extends AbstractProvider<
   constructor(options: GeoApiFrProviderOptions = {}) {
     super(options);
 
-    const host = 'https://api-adresse.data.gouv.fr';
-    this.searchUrl = options.searchUrl || `${host}/search`;
-    this.reverseUrl = options.reverseUrl || `${host}/reverse`;
+    const base = 'https://data.geopf.fr/geocodage';
+    this.searchUrl = options.searchUrl || `${base}/search`;
+    this.reverseUrl = options.reverseUrl || `${base}/reverse`;
   }
 
   endpoint({ query, type }: EndpointArgument) {


### PR DESCRIPTION
The API used by geoApiFrProvider has moved from DINUM to IGN :

  https://adresse.data.gouv.fr/blog/lapi-adresse-de-la-base-adresse-nationale-est-transferee-a-lign

Old API is being deprecated and doesn't work since February 2026.